### PR TITLE
docs: inventariar estado actual del producto

### DIFF
--- a/docs/product/vertical-beta-1.md
+++ b/docs/product/vertical-beta-1.md
@@ -1,0 +1,148 @@
+# Vertical Beta 1 — ¡Apaga las llamas!
+
+Fecha de decisión: 26 de julio de 2026
+
+## Objetivo de producto
+
+Demostrar de forma comprensible para la ciudadanía que las decisiones tomadas durante el invierno modifican las condiciones, los recursos disponibles y las consecuencias de un incendio durante el verano.
+
+La beta no presenta invierno y verano como modos independientes. Son dos momentos de una misma partida:
+
+- **Invierno:** prevención.
+- **Verano:** actuación condicionada por la prevención.
+
+## Público principal
+
+Ciudadanía.
+
+## Duración objetivo
+
+20–25 minutos.
+
+## Fase 1 — Invierno: prevención
+
+### 1. Introducción y rol
+
+- Presentación del municipio y del objetivo.
+- Elección de avatar.
+- Explicación breve del vínculo entre prevención y emergencia.
+
+### 2. Viviendas y edificios
+
+- Inspección mediante hotspots.
+- Selección de cuatro actuaciones.
+- Decisiones sobre canalones, fachadas, vegetación, huecos, accesos y edificios de apoyo.
+
+### 3. Fincas, vegetación y combustible
+
+- Priorización de limpieza, accesos, quemas, pastoreo y vegetación.
+- Recursos y capacidad de intervención limitados.
+
+### 4. Comunidad preparada
+
+- Planes familiares.
+- Población vulnerable.
+- Canales oficiales.
+- Puntos de apoyo.
+- Información para visitantes y senderistas.
+
+### 5. Balance preventivo
+
+El invierno termina con uno de estos estados:
+
+- Municipio preparado.
+- Preparación desigual.
+- Territorio vulnerable.
+
+## Estado que pasa al verano
+
+La fase de verano debe heredar, como mínimo:
+
+- Defensibilidad de viviendas.
+- Continuidad del combustible.
+- Accesibilidad.
+- Preparación familiar.
+- Población vulnerable identificada.
+- Confianza ciudadana.
+- Claridad de los canales oficiales.
+- Recursos disponibles.
+- Fortalezas y vulnerabilidades generadas por las decisiones.
+
+## Transición
+
+Se declara un incendio. Antes de actuar, el juego muestra de manera explícita las condiciones heredadas del invierno y explica que la emergencia comienza con ese margen, no desde cero.
+
+## Fase 2 — Verano: actuación
+
+### 6. Primer aviso
+
+- Verificar localización.
+- Movilizar medios.
+- Ordenar accesos.
+- Comunicar sin generar alarma innecesaria.
+
+### 7. Escalada del incendio
+
+- El ataque inicial no resuelve completamente el fuego.
+- El jugador debe asignar recursos limitados.
+- Las vulnerabilidades del invierno modifican dificultad y costes.
+
+### 8. Cambio de viento y amenaza a viviendas
+
+- Decisión entre evacuación, confinamiento, defensa del núcleo o redistribución de medios.
+- Accesos, defensibilidad y preparación ciudadana alteran las opciones disponibles.
+
+### 9. Crisis de comunicación
+
+- Saturación del 112.
+- Desinformación o imagen antigua viral.
+- Solo pueden ejecutarse dos actuaciones por escena.
+
+### 10. Noche y agotamiento operativo
+
+- Retirada de medios aéreos.
+- Relevo de cuadrillas o mantenimiento del ataque.
+- La preparación previa determina cuánto margen operativo queda.
+
+## Informe final causal
+
+El resultado debe explicar:
+
+- Qué medida preventiva redujo daños.
+- Qué carencia agravó la emergencia.
+- Qué decisiones de verano compensaron errores previos.
+- Qué daños podrían haberse evitado.
+- Población protegida.
+- Viviendas afectadas.
+- Confusión pública.
+- Seguridad de los equipos.
+- Resultado alternativo con una prevención diferente.
+
+## Desenlaces
+
+- **Respuesta favorable:** la prevención proporciona margen operativo.
+- **Contención con daños:** la preparación parcial obliga a corregir durante la emergencia.
+- **Emergencia desbordada:** las vulnerabilidades acumuladas y la respuesta insuficiente superan la capacidad del operativo.
+
+## Criterio de éxito de la beta
+
+Dos partidas con decisiones preventivas diferentes deben producir condiciones, opciones y resultados claramente distintos durante el verano.
+
+## Base técnica acordada
+
+- Aplicación Fastify modular.
+- Motor TypeScript separado de la vista.
+- Reglas narrativas y heurísticas explicables.
+- Territorio ilustrado/SVG.
+- Contenido externo y editable.
+- Informe final generado desde el estado real de la partida.
+
+## Fuera de alcance
+
+- MapLibre y PostGIS.
+- Mapas geográficos reales.
+- Simulación física o celular avanzada.
+- Cuentas de usuario.
+- Multijugador.
+- Todos los escenarios existentes.
+- Frontend y backend separados.

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -19,9 +19,9 @@ El repositorio contiene tres capas de avance distintas:
 2. **Contenido editorial estructurado**, con alrededor de cincuenta escenarios, variables, impactos, decisiones, textos revisables e internacionalización inicial.
 3. **Un prototipo vertical funcional**, servido por Fastify y construido dentro de una única página HTML/JavaScript, con prevención, primer aviso, crisis, decisiones, variables, resultados y reinicio.
 
-El producto ya supera el estado de maqueta estática. Sin embargo, la arquitectura objetivo documentada —Next.js, React, Zustand, MapLibre, PostgreSQL/PostGIS, Redis, CQRS completo y despliegue distribuido— no está implementada. El juego funcional actual vive principalmente dentro de `src/interfaces/http/prototype-page.ts`, mientras que el dominio TypeScript separado solo cubre un ejemplo mínimo de incidentes activos.
+El producto ya supera el estado de maqueta estática. La dirección acordada es consolidar la aplicación Fastify existente mediante una arquitectura modular, sin migrar en esta fase a Next.js ni separar frontend y backend. El juego funcional actual vive principalmente dentro de `src/interfaces/http/prototype-page.ts`, mientras que el dominio TypeScript separado solo cubre un ejemplo mínimo de incidentes activos.
 
-La prioridad no debería ser añadir más arquitectura ni más pantallas, sino consolidar la beta vertical existente: separar motor, interfaz y contenido; definir el alcance real del MVP; eliminar duplicidades; añadir pruebas; y decidir qué partes de la arquitectura objetivo son necesarias ahora.
+La prioridad no debería ser añadir más arquitectura ni más pantallas, sino consolidar la beta vertical existente: separar motor, interfaz y contenido; cerrar el alcance del MVP; eliminar duplicidades; añadir pruebas; e implementar un territorio ilustrado/SVG coherente con las reglas narrativas y heurísticas explicables acordadas.
 
 ---
 
@@ -31,10 +31,10 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 |---|---|---|---|
 | Concepto de serious game sobre incendios | Existe y es aprovechable | `README.md`, `docs/product/vision-and-scope.md` | La propuesta de valor está formulada. |
 | Bucle prevención → crisis → resultado | Existe y es aprovechable | `src/content/campaign.ts`, `prototype-page.ts` | Ya hay una beta vertical navegable. |
-| Público objetivo | Existe, pero necesita revisión | `docs/product/vision-and-scope.md` | Mezcla gestores, estudiantes y ciudadanía. Hay que elegir un público principal para el MVP. |
-| Objetivo educativo | Existe, pero necesita revisión | Documentación de producto y escenarios | Conviven formación técnica, sensibilización ciudadana y divulgación. Debe priorizarse uno. |
-| Nombre e identidad del producto | Existe, pero necesita revisión | `Guardián del Bosque` en documentación y `¡Apaga las llamas!` en interfaz | Hay dos nombres de producto. Debe decidirse marca principal y posible subtítulo. |
-| Alcance del MVP | Es solo documentación o propuesta | Varias especificaciones | Hay propuestas diferentes: ciclo estacional, beta de comunicación, prevención y simulación geoespacial. Falta cerrar un único alcance. |
+| Público objetivo | Existe y es aprovechable | Decisión de producto | El público principal de la beta es la ciudadanía. Gestores y estudiantes quedan como públicos secundarios. |
+| Objetivo educativo | Existe, pero necesita revisión | Documentación de producto y escenarios | Debe concretarse qué aprendizaje ciudadano prioritario debe demostrar la beta. |
+| Nombre e identidad del producto | Existe y es aprovechable | Decisión de producto e interfaz | La marca oficial es `¡Apaga las llamas!`. Las referencias a `Guardián del Bosque` deben migrarse o archivarse. |
+| Alcance del MVP | Es solo documentación o propuesta | Varias especificaciones | Hay propuestas diferentes: ciclo estacional, beta de comunicación y prevención. Falta cerrar el recorrido exacto de la beta. |
 | KPIs | Es solo documentación o propuesta | `docs/product/vision-and-scope.md` | No hay analítica implementada. |
 | Modelo de publicación y explotación | Falta implementar | No localizado | Debe definirse si será demostrador, producto educativo, licencia institucional o publicación editorial. |
 
@@ -62,10 +62,11 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 | Resultados dinámicos | Existe y es aprovechable | `finalizeCampaignResult()` | Calcula protección, daños, confianza y capacidad operativa. |
 | Reinicio de partida | Existe y es aprovechable | `buildInitialState()` y botón de reinicio | Funcional en memoria. |
 | Persistencia de partida | Falta implementar | No localizada | No hay `localStorage`, base de datos ni sincronización. |
-| Motor desacoplado de la interfaz | Falta implementar | La lógica principal está embebida en `prototype-page.ts` | Debe extraerse a módulos TypeScript testeables. |
+| Motor desacoplado de la interfaz | Falta implementar | La lógica principal está embebida en `prototype-page.ts` | Debe extraerse a módulos TypeScript testeables dentro de la aplicación Fastify. |
 | Dominio separado de incidentes | Existe, pero necesita revisión | `FireIncident`, repositorio en memoria, query handler | Es un ejemplo aislado y no gobierna la partida real. Debe integrarse o retirarse. |
-| Simulación geoespacial / propagación | Es solo documentación o propuesta | Arquitectura, dominio y backlog | No hay grilla, autómata celular ni cálculo espacial implementado. |
-| Eventos de dominio auditables | Es solo documentación o propuesta | `docs/domain/game-design-spec.md` | La interfaz guarda logs, pero no existe un event store o modelo de eventos de dominio. |
+| Motor narrativo y heurístico explicable | Existe, pero necesita revisión | Variables, impactos, condiciones y cálculo de resultados | Es la dirección acordada para la beta. Debe formalizarse, documentarse y probarse. |
+| Simulación geoespacial / propagación física | Fuera del alcance de la beta | Arquitectura, dominio y backlog | No se implementará como motor celular en esta fase. |
+| Eventos de dominio auditables | Es solo documentación o propuesta | `docs/domain/game-design-spec.md` | La interfaz guarda logs, pero no existe un modelo modular de eventos del juego. |
 
 ## 4. Interfaz y experiencia de usuario
 
@@ -75,7 +76,7 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 | Playtest de escenarios | Existe y es aprovechable | `/game-content`, `game-content-page.ts` | Herramienta útil para revisar contenidos de forma aislada. |
 | Diseño responsive inicial | Existe y es aprovechable | Media queries en ambas páginas | Hay adaptación a tablet y móvil. |
 | Accesibilidad inicial | Existe, pero necesita revisión | Foco visible, diálogo, reducción de movimiento | Falta auditoría WCAG, semántica completa y pruebas con teclado/lector. |
-| Componentización | Falta implementar | HTML, CSS y JS concentrados en dos archivos grandes | Debe dividirse por componentes y responsabilidades. |
+| Componentización | Falta implementar | HTML, CSS y JS concentrados en dos archivos grandes | Debe dividirse por componentes y responsabilidades sin abandonar Fastify. |
 | Sistema de diseño reutilizable | Es solo documentación o propuesta | Mockups e iconografía, estilos embebidos | No hay tokens ni componentes compartidos. |
 | Claridad de información | Existe, pero necesita revisión | Mucha información y textos largos | Necesita prueba de usabilidad y jerarquía por fase. |
 | Estados de carga y error | Existe y es aprovechable | `contentStatus`, `contentError` | Implementación básica. |
@@ -85,13 +86,14 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Representación visual del territorio | Existe, pero necesita revisión | SVG de inspección e imagen de crisis | Sirve para prototipo, no para simulación territorial. |
+| Representación visual del territorio | Existe, pero necesita revisión | SVG de inspección e imagen de crisis | Debe evolucionar hacia un territorio ilustrado/SVG coherente y reutilizable. |
 | Hotspots interactivos | Existe y es aprovechable | `prevention-inspections.ts` y SVG de interfaz | Buena base para decisiones localizadas. |
-| Capas cartográficas | Falta implementar | No hay MapLibre ni GeoJSON operativo | Documentado, pero no materializado. |
-| Perímetro dinámico del incendio | Falta implementar | No localizado | El fuego cambia como métricas, no como geometría. |
-| Movimiento de recursos | Falta implementar | No localizado | No hay rutas, posiciones ni tiempos espaciales. |
-| Datos geográficos reales | Falta implementar | No hay PostGIS ni datasets activos | Debe decidirse si el MVP necesita territorio real o ficticio. |
-| MapLibre / Turf | Es solo documentación o propuesta | `docs/frontend/frontend-spec.md` | No aparece en dependencias ni código actual. |
+| Territorio ilustrado/SVG para la beta | Falta implementar | Decisión de producto | Es la solución acordada. Debe incluir zonas, carreteras, infraestructuras, recursos y estados visuales. |
+| Capas narrativas del mapa | Falta implementar | No localizado | Deben responder a eventos y variables sin requerir cartografía real. |
+| Perímetro dinámico del incendio | Falta implementar | No localizado | Puede representarse mediante estados y geometrías SVG predefinidas. |
+| Movimiento de recursos | Falta implementar | No localizado | Puede resolverse con posiciones y rutas SVG narrativas. |
+| Datos geográficos reales | Fuera del alcance de la beta | No hay PostGIS ni datasets activos | No son necesarios para validar el producto ciudadano. |
+| MapLibre / Turf / PostGIS | Pospuesto | Documentación técnica | Se reconsiderará solo si una fase posterior necesita territorio real. |
 
 ## 6. Contenidos editoriales e internacionalización
 
@@ -112,7 +114,7 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 | Imágenes principales | Existe y es aprovechable | `public/images/operational-command-hero.png`, `gameplay-wildfire-scene.png`, `primer-aviso-humo.png` | Funcionan como fondos y apoyo visual. |
 | Avatares | Existe y es aprovechable | Tres PNG de perfil forestal | Integrados como rutas HTTP. |
 | Iconografía funcional | Existe, pero necesita revisión | Emojis y símbolos embebidos | No constituye una familia visual propia ni accesible. |
-| Sistema de iconos SVG | Falta implementar | No localizado | Debe crearse si se mantiene la dirección visual propuesta. |
+| Sistema de iconos SVG | Falta implementar | No localizado | Debe coordinarse con el territorio ilustrado/SVG. |
 | Gestión de assets | Existe, pero necesita revisión | Rutas individuales en Fastify | Conviene servir `public` de forma estática y documentar licencias/origen. |
 | Licencias y atribución | Falta implementar | No localizado | Debe registrarse para publicación. |
 
@@ -120,13 +122,14 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Servidor Fastify | Existe y es aprovechable | `src/interfaces/http/server.ts`, `app.ts` | Sirve prototipo, contenido e imágenes. |
+| Servidor Fastify | Existe y es aprovechable | `src/interfaces/http/server.ts`, `app.ts` | Es la base técnica oficial de la beta. |
+| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript y decisión de arquitectura | Debe modularizar motor, interfaz, contenido y servicios sin migración de framework. |
 | Healthcheck | Existe y es aprovechable | `/health` | Básico y funcional. |
 | Endpoint de contenido | Existe y es aprovechable | `/game-content/data` | Entrega variables, escenarios y campaña. |
 | Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Usa datos de ejemplo de Madrid y Sevilla, desconectados del juego. |
-| Persistencia en PostgreSQL/PostGIS | Falta implementar | No hay Prisma ni dependencia PostgreSQL | Solo documentación. |
-| Redis y bus de eventos | Es solo documentación o propuesta | Especificación backend | No implementados. |
-| OpenAPI y contratos | Falta implementar | Backlog pendiente | No se localizaron contratos ejecutables. |
+| Persistencia en PostgreSQL/PostGIS | Fuera del alcance de la beta | No hay Prisma ni dependencia PostgreSQL | No es necesaria para la beta inicial. |
+| Redis y bus de eventos | Pospuesto | Especificación backend | No son necesarios para la siguiente fase. |
+| OpenAPI y contratos | Falta implementar | Backlog pendiente | Solo será prioritario para endpoints que formen parte estable del producto. |
 | Autenticación y usuarios | Falta implementar | No localizado | No necesaria para la beta local, sí para cuentas o informes centralizados. |
 
 ## 9. Pruebas y calidad
@@ -146,7 +149,8 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
 | Ejecución local | Existe y es aprovechable | `npm run dev`, `npm run build`, `npm start` | Base suficiente para desarrollo. |
-| Railway + Vercel | Es solo documentación o propuesta | `docs/analysis/gaps-and-decisions.md` | La implementación actual es una única app Fastify, no frontend/backend separados. |
+| Despliegue de una aplicación Fastify | Falta implementar | Decisión de arquitectura | Debe elegirse un proveedor compatible y evitar separar frontend/backend en la beta. |
+| Railway + Vercel | Necesita revisión | `docs/analysis/gaps-and-decisions.md` | Vercel deja de ser necesario si se mantiene una sola aplicación Fastify. |
 | Docker | Falta implementar o no localizado | No localizado | Puede no ser necesario en la siguiente fase. |
 | Entornos y secretos | Es solo documentación o propuesta | Documentación DevOps | No hay infraestructura real verificada. |
 | Observabilidad | Falta implementar | Fastify usa log básico, sin métricas ni trazas | No prioritaria hasta estabilizar el MVP. |
@@ -158,24 +162,29 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 |---|---|---|---|
 | Índice documental | Existe y es aprovechable | `docs/README.md` | Buena navegación general. |
 | Especificaciones por área | Existe y es aprovechable | `docs/product`, `architecture`, `frontend`, `backend`, etc. | Cobertura amplia. |
-| Backlog documental | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa que el prototipo actual. |
+| Backlog documental | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa que la decisión actual. |
 | Gaps y riesgos | Existe y es aprovechable | `docs/analysis/gaps-and-decisions.md` | Ya reconoce sobreingeniería y falta de implementación. |
 | Documentación histórica | Existe, pero necesita revisión | `docs/legacy`, `buzon`, manuales | Mucho valor editorial, pero mezcla material vigente, propuesta y archivo. |
-| Issues y pull requests como gestión | Falta estructurar | No hay PR recientes y el backlog no está trasladado a Issues | Debe hacerse después de aprobar este inventario. |
+| Issues y pull requests como gestión | Falta estructurar | El backlog no está trasladado a Issues | Debe hacerse después de aprobar este inventario. |
 | Criterios de terminado | Es solo documentación o propuesta | Plantillas y guías | Falta aplicarlos a entregables reales. |
 
 ---
 
-## Contradicciones y decisiones que deben resolverse antes del roadmap
+## Decisiones de producto resueltas
 
-1. **Marca:** `Guardián del Bosque` frente a `¡Apaga las llamas!`.
-2. **Público principal:** gestores, estudiantes o ciudadanía.
-3. **Producto inicial:** ciclo estacional completo, newsgame narrativo o simulador técnico.
-4. **Arquitectura:** mantener una aplicación Fastify modular o migrar ya a Next.js + backend separado.
-5. **Mapa:** territorio ilustrado/SVG para la beta o MapLibre/PostGIS desde el principio.
-6. **Motor:** reglas narrativas y heurísticas explicables o simulación celular geoespacial.
-7. **Fuente editorial:** archivos de escenario, catálogo i18n o documentos Markdown.
-8. **Dominio:** integrar el prototipo actual en módulos TypeScript o desarrollar el dominio DDD documentado desde cero.
+1. **Marca:** `¡Apaga las llamas!`.
+2. **Público principal:** ciudadanía.
+3. **Arquitectura:** mantener y modularizar la aplicación Fastify.
+4. **Mapa:** territorio ilustrado/SVG para la beta.
+5. **Motor:** reglas narrativas y heurísticas explicables.
+
+## Decisiones aún pendientes antes del roadmap
+
+1. **Producto inicial:** recorrido exacto de la beta dentro del material existente.
+2. **Objetivo educativo:** aprendizaje ciudadano prioritario y criterios para evaluarlo.
+3. **Fuente editorial:** archivos de escenario, catálogo i18n o documentos Markdown.
+4. **Dominio:** forma concreta de extraer el motor actual a módulos TypeScript y retirar o integrar el dominio de incidentes de ejemplo.
+5. **Publicación:** formato de explotación y despliegue inicial.
 
 ## Elementos que conviene conservar
 
@@ -193,39 +202,40 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 ## Elementos que conviene revisar o simplificar
 
 - Arquitectura hexagonal + DDD + CQRS completa para el tamaño actual.
-- Next.js, Redis, RabbitMQ, PostGIS y microcapas antes de validar el juego.
+- Next.js, Redis, RabbitMQ y PostGIS antes de validar el juego.
 - Duplicidad entre campaña estacional y ruta vertical narrativa.
 - Dos modelos de dominio desconectados.
 - Archivos de interfaz de miles de líneas.
 - Textos duplicados y problemas de codificación.
 - Uso de emojis como iconografía final.
 - Endpoint de incendios de ejemplo sin relación con el producto.
+- Referencias documentales a `Guardián del Bosque`.
 
 ## Vacíos prioritarios
 
-1. Definir el MVP y su público principal.
-2. Extraer el motor del archivo de interfaz.
+1. Cerrar el recorrido exacto y objetivo educativo de la beta ciudadana.
+2. Extraer el motor del archivo de interfaz a módulos TypeScript dentro de Fastify.
 3. Crear pruebas del motor y del recorrido vertical.
 4. Documentar el grafo real de escenas y dependencias.
 5. Resolver la fuente única de verdad editorial.
-6. Añadir persistencia local y reanudación.
-7. Crear un informe final causal más completo.
-8. Decidir el nivel de mapa necesario para la beta.
+6. Diseñar e implementar el territorio ilustrado/SVG.
+7. Añadir persistencia local y reanudación.
+8. Crear un informe final causal más completo.
 9. Convertir el backlog aprobado en GitHub Issues.
 10. Configurar CI básico: typecheck, build y tests.
 
 ## Recomendación de siguiente hito
 
-No iniciar todavía la migración a Next.js/PostGIS.
-
-El siguiente hito debería ser **consolidar una beta vertical jugable y mantenible** con este alcance:
+El siguiente hito debería ser **consolidar una beta vertical ciudadana, jugable y mantenible** con este alcance:
 
 - Un recorrido completo de prevención, primer aviso, crisis y resultado.
-- Motor TypeScript separado de la vista.
+- Motor TypeScript separado de la vista y ejecutado dentro de Fastify.
+- Reglas narrativas y heurísticas explicables.
 - Contenido externo y editable.
+- Territorio ilustrado/SVG con estados vinculados a decisiones.
 - Persistencia local.
 - Resultado causal basado en decisiones.
 - Pruebas unitarias e integración.
-- Interfaz actual refactorizada sin rediseño total.
+- Interfaz actual refactorizada sin migración de framework.
 
-Solo después de probar esa beta con usuarios y validar la necesidad territorial debería decidirse si se incorpora MapLibre/PostGIS y un backend persistente.
+MapLibre, PostGIS, Next.js, Redis y una simulación física o celular quedan fuera de la beta. Solo se reconsiderarán después de validar el producto con ciudadanía y demostrar una necesidad concreta.

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -10,6 +10,7 @@ Rama base: `main`
 - **Existe, pero necesita revisión**: hay una base útil, aunque presenta deuda, inconsistencias o falta de validación.
 - **Es solo documentación o propuesta**: está descrito, pero no materializado en el producto.
 - **Falta implementar**: no se ha localizado una implementación funcional en la rama revisada.
+- **Fuera del alcance de la beta**: decisión explícita de no incluirlo en la Vertical Beta 1.
 
 ## Resumen ejecutivo
 
@@ -17,11 +18,16 @@ El repositorio contiene tres capas de avance distintas:
 
 1. **Documentación extensa de producto y arquitectura**, con visión, dominio, frontend, backend, datos, testing, DevOps y gobierno del proyecto.
 2. **Contenido editorial estructurado**, con alrededor de cincuenta escenarios, variables, impactos, decisiones, textos revisables e internacionalización inicial.
-3. **Un prototipo vertical funcional**, servido por Fastify y construido dentro de una única página HTML/JavaScript, con prevención, primer aviso, crisis, decisiones, variables, resultados y reinicio.
+3. **Un prototipo vertical funcional**, servido por Fastify y construido principalmente dentro de una página HTML/JavaScript, con prevención, primer aviso, crisis, decisiones, variables, resultados y reinicio.
 
-El producto ya supera el estado de maqueta estática. La dirección acordada es consolidar la aplicación Fastify existente mediante una arquitectura modular, sin migrar en esta fase a Next.js ni separar frontend y backend. El juego funcional actual vive principalmente dentro de `src/interfaces/http/prototype-page.ts`, mientras que el dominio TypeScript separado solo cubre un ejemplo mínimo de incidentes activos.
+El producto ya supera el estado de maqueta estática. La dirección acordada es consolidar la aplicación Fastify existente mediante una arquitectura modular, sin migrar en esta fase a Next.js ni separar frontend y backend.
 
-La prioridad no debería ser añadir más arquitectura ni más pantallas, sino consolidar la beta vertical existente: separar motor, interfaz y contenido; cerrar el alcance del MVP; eliminar duplicidades; añadir pruebas; e implementar un territorio ilustrado/SVG coherente con las reglas narrativas y heurísticas explicables acordadas.
+La **Vertical Beta 1** queda definida como una partida ciudadana completa en dos momentos conectados:
+
+- **Invierno:** prevención en viviendas, territorio y comunidad.
+- **Verano:** actuación ante un incendio condicionada por lo realizado —o no realizado— durante el invierno.
+
+El aprendizaje central es comprobar que la prevención cambia el margen operativo, los daños, la exposición de la población y la dificultad de las decisiones posteriores.
 
 ---
 
@@ -29,144 +35,190 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Concepto de serious game sobre incendios | Existe y es aprovechable | `README.md`, `docs/product/vision-and-scope.md` | La propuesta de valor está formulada. |
-| Bucle prevención → crisis → resultado | Existe y es aprovechable | `src/content/campaign.ts`, `prototype-page.ts` | Ya hay una beta vertical navegable. |
-| Público objetivo | Existe y es aprovechable | Decisión de producto | El público principal de la beta es la ciudadanía. Gestores y estudiantes quedan como públicos secundarios. |
-| Objetivo educativo | Existe, pero necesita revisión | Documentación de producto y escenarios | Debe concretarse qué aprendizaje ciudadano prioritario debe demostrar la beta. |
-| Nombre e identidad del producto | Existe y es aprovechable | Decisión de producto e interfaz | La marca oficial es `¡Apaga las llamas!`. Las referencias a `Guardián del Bosque` deben migrarse o archivarse. |
-| Alcance del MVP | Es solo documentación o propuesta | Varias especificaciones | Hay propuestas diferentes: ciclo estacional, beta de comunicación y prevención. Falta cerrar el recorrido exacto de la beta. |
-| KPIs | Es solo documentación o propuesta | `docs/product/vision-and-scope.md` | No hay analítica implementada. |
-| Modelo de publicación y explotación | Falta implementar | No localizado | Debe definirse si será demostrador, producto educativo, licencia institucional o publicación editorial. |
+| Concepto de serious game sobre incendios | Existe y es aprovechable | `README.md`, documentación y prototipo | La propuesta de valor está formulada. |
+| Marca | Existe y es aprovechable | Decisión de producto | La marca oficial es **`¡Apaga las llamas!`**. Las referencias a `Guardián del Bosque` deben migrarse o archivarse. |
+| Público principal | Existe y es aprovechable | Decisión de producto | La beta se dirige a ciudadanía. Gestores y estudiantes quedan como públicos secundarios. |
+| Objetivo educativo | Existe y es aprovechable | Decisión de producto | Mostrar que la prevención de invierno modifica las condiciones y consecuencias de la emergencia de verano. |
+| Estructura temporal | Existe y es aprovechable | `campaign.ts`, inspecciones y escenarios | Invierno y verano no son modos separados, sino dos momentos causales de una misma partida. |
+| Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Recorrido oficial cerrado para la siguiente fase. |
+| Duración objetivo | Existe, pero necesita validación | Definición de la beta | Referencia inicial: 20–25 minutos. Debe comprobarse con usuarios. |
+| KPIs | Es solo documentación o propuesta | Documentación de producto | Falta convertirlos en métricas concretas de validación. |
+| Modelo de publicación y explotación | Falta implementar | No localizado | Debe definirse en una fase posterior: demostrador, producto editorial o licencia institucional. |
+
+### Recorrido oficial de la Vertical Beta 1
+
+#### Introducción
+
+1. Presentación del municipio, rol y objetivo.
+2. Elección de avatar.
+
+#### Fase 1 — Invierno: prevención
+
+3. **Viviendas y edificios:** inspección mediante hotspots y selección limitada de actuaciones.
+4. **Fincas, vegetación y combustible:** limpieza, accesos, quemas, pastoreo y continuidad vegetal.
+5. **Comunidad preparada:** familias, población vulnerable, canales oficiales, visitantes y puntos de apoyo.
+6. **Balance preventivo:** municipio preparado, preparación desigual o territorio vulnerable.
+
+#### Transición invierno–verano
+
+7. Declaración del incendio y presentación del estado heredado:
+   - defensibilidad de viviendas;
+   - continuidad del combustible;
+   - accesibilidad;
+   - preparación familiar;
+   - población vulnerable identificada;
+   - confianza ciudadana;
+   - claridad de canales oficiales;
+   - recursos disponibles.
+
+#### Fase 2 — Verano: actuación
+
+8. **Primer aviso:** verificación, movilización inicial y comunicación prudente.
+9. **Escalada del incendio:** asignación limitada de medios.
+10. **Cambio de viento:** amenaza a viviendas, evacuación y defensa operativa.
+11. **Crisis de comunicación:** saturación del 112 y desinformación visual.
+12. **Noche y agotamiento:** retirada de medios aéreos, defensa nocturna y relevo de equipos.
+13. **Informe final causal:** relación entre prevención, actuación y consecuencias.
+
+#### Desenlaces
+
+- Respuesta favorable: la prevención proporciona margen operativo.
+- Contención con daños: preparación parcial y decisiones correctivas.
+- Emergencia desbordada: vulnerabilidades acumuladas y respuesta insuficiente.
+
+#### Criterio de éxito del producto
+
+Dos partidas con decisiones preventivas diferentes deben producir condiciones, dificultades y resultados claramente distintos durante el verano.
+
+---
 
 ## 2. Escenarios y narrativa
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
 | Catálogo de escenarios | Existe y es aprovechable | `src/content/scenarios/index.ts` | Hay aproximadamente 50 escenarios agrupados por prevención, comunicación y operaciones. |
-| Tipado común de escenarios | Existe y es aprovechable | `src/domain/types/scenario.ts` | Incluye opciones, impactos, requisitos, desbloqueos, acciones, combinaciones y resultados. |
-| Ruta vertical de comunicación | Existe y es aprovechable | `CRISIS_ROUTE_MODULE`, escenarios de comunicación | Tiene selección limitada de acciones, métricas y transición entre escenas. |
-| Pantallas preventivas | Existe y es aprovechable | `src/content/prevention-inspections.ts` | Hay hotspots, acciones, límites, flags, combinaciones y consecuencias diferidas. |
-| Primer aviso y balance preventivo | Existe y es aprovechable | `src/content/prevention-balance.ts` y documentación asociada | Conecta las decisiones preventivas con la crisis. |
-| Árbol narrativo global | Existe, pero necesita revisión | `nextLogic`, `routeLogic`, campaña | Hay ramificación parcial, pero no un grafo único y documentado de toda la experiencia. |
-| Coherencia de IDs, nombres y categorías | Existe, pero necesita revisión | Historial de renombrados y archivos eliminados | Conviene validar duplicados, saltos de numeración y escenarios huérfanos. |
-| Validación experta | Falta implementar | No localizada como proceso cerrado | Hay notas de fuentes, pero no consta aprobación formal por especialistas. |
-| Versionado editorial | Existe, pero necesita revisión | `docs/revision-textos/`, `src/content/i18n/` | Buena base, aunque hay caracteres dañados y duplicidad entre textos fuente y plantilla. |
+| Tipado común | Existe y es aprovechable | `src/domain/types/scenario.ts` | Incluye opciones, impactos, requisitos, desbloqueos, acciones, combinaciones y resultados. |
+| Pantallas preventivas | Existe y es aprovechable | `src/content/prevention-inspections.ts` | Son la base del invierno de la beta. |
+| Balance preventivo y primer aviso | Existe y es aprovechable | `src/content/prevention-balance.ts` | Es el puente central entre invierno y verano. |
+| Escenarios operativos de verano | Existe y es aprovechable | Escenarios `os-*` | Existe material suficiente para primer envío, escalado, viento, evacuación, noche y relevo. |
+| Ruta de comunicación | Existe y es aprovechable | `CRISIS_ROUTE_MODULE`, `cs-018`, `cs-023` | Aporta saturación del 112 y desinformación. |
+| Selección exacta de escenarios beta | Existe, pero necesita revisión | Vertical Beta 1 y catálogo | Debe fijarse el ID definitivo de cada escena y retirar duplicados. |
+| Grafo narrativo completo | Falta implementar | `nextLogic`, `routeLogic` parciales | Debe documentarse el flujo oficial y sus bifurcaciones. |
+| Coherencia de IDs y categorías | Existe, pero necesita revisión | Historial de renombrados | Hay que localizar duplicados, escenarios huérfanos y saltos de numeración. |
+| Validación experta | Falta implementar | No consta proceso cerrado | Debe revisarse el contenido operativo antes de publicación. |
 
 ## 3. Motor de juego y dominio
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Estado de partida | Existe y es aprovechable | `buildInitialState()` en `prototype-page.ts` | Registra fases, recursos, terreno, inspecciones, crisis y resultado. |
-| Aplicación de impactos y límites | Existe y es aprovechable | `applyVector`, métricas de inspección y crisis | Ya existen reglas operativas simples. |
-| Condiciones y transiciones | Existe y es aprovechable | `parseConditionExpression`, `scenarioNextStep`, `routeConditionMatches` | Hay evaluación de condiciones declarativas. |
+| Estado de partida | Existe y es aprovechable | `buildInitialState()` | Registra fases, recursos, terreno, inspecciones, crisis y resultado. |
+| Aplicación de impactos | Existe y es aprovechable | `applyVector`, impactos de escenarios | Ya existen reglas heurísticas simples. |
+| Condiciones y transiciones | Existe y es aprovechable | `parseConditionExpression`, `scenarioNextStep` | Hay evaluación declarativa inicial. |
+| Herencia invierno–verano | Existe, pero necesita revisión | Balance y métricas agregadas | Es el núcleo del producto y debe formalizarse en un único contrato de estado. |
 | Resultados dinámicos | Existe y es aprovechable | `finalizeCampaignResult()` | Calcula protección, daños, confianza y capacidad operativa. |
-| Reinicio de partida | Existe y es aprovechable | `buildInitialState()` y botón de reinicio | Funcional en memoria. |
-| Persistencia de partida | Falta implementar | No localizada | No hay `localStorage`, base de datos ni sincronización. |
-| Motor desacoplado de la interfaz | Falta implementar | La lógica principal está embebida en `prototype-page.ts` | Debe extraerse a módulos TypeScript testeables dentro de la aplicación Fastify. |
-| Dominio separado de incidentes | Existe, pero necesita revisión | `FireIncident`, repositorio en memoria, query handler | Es un ejemplo aislado y no gobierna la partida real. Debe integrarse o retirarse. |
-| Motor narrativo y heurístico explicable | Existe, pero necesita revisión | Variables, impactos, condiciones y cálculo de resultados | Es la dirección acordada para la beta. Debe formalizarse, documentarse y probarse. |
-| Simulación geoespacial / propagación física | Fuera del alcance de la beta | Arquitectura, dominio y backlog | No se implementará como motor celular en esta fase. |
-| Eventos de dominio auditables | Es solo documentación o propuesta | `docs/domain/game-design-spec.md` | La interfaz guarda logs, pero no existe un modelo modular de eventos del juego. |
+| Informe causal | Existe, pero necesita revisión | Resultado y logs actuales | Debe explicar qué decisión preventiva causó o evitó cada consecuencia relevante. |
+| Persistencia de partida | Falta implementar | No localizada | Añadir `localStorage` para reanudar la beta. |
+| Motor separado de la interfaz | Falta implementar | Lógica embebida en `prototype-page.ts` | Extraer a módulos TypeScript testeables dentro de Fastify. |
+| Dominio de incidentes de ejemplo | Existe, pero necesita revisión | `FireIncident` y repositorio en memoria | Está desconectado del juego; debe integrarse o retirarse. |
+| Motor narrativo y heurístico | Existe, pero necesita revisión | Variables, impactos y condiciones | Es la dirección oficial. Debe documentarse y probarse. |
+| Simulación física o celular | Fuera del alcance de la beta | Documentación avanzada | No se implementará en Vertical Beta 1. |
 
 ## 4. Interfaz y experiencia de usuario
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Prototipo web navegable | Existe y es aprovechable | `/` y `/prototype`, `prototype-page.ts` | Incluye seis etapas, decisiones y resultados. |
-| Playtest de escenarios | Existe y es aprovechable | `/game-content`, `game-content-page.ts` | Herramienta útil para revisar contenidos de forma aislada. |
-| Diseño responsive inicial | Existe y es aprovechable | Media queries en ambas páginas | Hay adaptación a tablet y móvil. |
-| Accesibilidad inicial | Existe, pero necesita revisión | Foco visible, diálogo, reducción de movimiento | Falta auditoría WCAG, semántica completa y pruebas con teclado/lector. |
-| Componentización | Falta implementar | HTML, CSS y JS concentrados en dos archivos grandes | Debe dividirse por componentes y responsabilidades sin abandonar Fastify. |
-| Sistema de diseño reutilizable | Es solo documentación o propuesta | Mockups e iconografía, estilos embebidos | No hay tokens ni componentes compartidos. |
-| Claridad de información | Existe, pero necesita revisión | Mucha información y textos largos | Necesita prueba de usabilidad y jerarquía por fase. |
-| Estados de carga y error | Existe y es aprovechable | `contentStatus`, `contentError` | Implementación básica. |
-| Sonido y narrativa audiovisual | Falta implementar en esta versión | No localizado en la rama revisada | Puede existir en prototipos históricos, pero no en la beta actual. |
+| Prototipo navegable | Existe y es aprovechable | `/`, `/prototype` | Incluye recorrido y resultados. |
+| Playtest editorial | Existe y es aprovechable | `/game-content` | Útil para revisar escenarios de forma aislada. |
+| Responsive inicial | Existe y es aprovechable | Media queries | Requiere validación real en móvil y escritorio. |
+| Accesibilidad inicial | Existe, pero necesita revisión | Foco, diálogo, reducción de movimiento | Falta auditoría WCAG y pruebas completas con teclado. |
+| Distinción visual invierno–verano | Existe, pero necesita revisión | Etapas actuales | Debe reforzarse sin romper la continuidad causal. |
+| Componentización | Falta implementar | Dos archivos de interfaz muy grandes | Separar vistas, componentes, estado y eventos. |
+| Sistema de diseño | Es solo documentación o propuesta | Estilos embebidos y referencias visuales | Crear tokens y componentes reutilizables. |
+| Claridad informativa | Existe, pero necesita revisión | Textos largos y alta densidad | Jerarquizar contexto, decisión, consecuencias y ayuda. |
+| Sonido | Falta implementar en la versión actual | No localizado | Secundario frente al motor y al recorrido. |
 
 ## 5. Mapa y territorio
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Representación visual del territorio | Existe, pero necesita revisión | SVG de inspección e imagen de crisis | Debe evolucionar hacia un territorio ilustrado/SVG coherente y reutilizable. |
-| Hotspots interactivos | Existe y es aprovechable | `prevention-inspections.ts` y SVG de interfaz | Buena base para decisiones localizadas. |
-| Territorio ilustrado/SVG para la beta | Falta implementar | Decisión de producto | Es la solución acordada. Debe incluir zonas, carreteras, infraestructuras, recursos y estados visuales. |
-| Capas narrativas del mapa | Falta implementar | No localizado | Deben responder a eventos y variables sin requerir cartografía real. |
-| Perímetro dinámico del incendio | Falta implementar | No localizado | Puede representarse mediante estados y geometrías SVG predefinidas. |
-| Movimiento de recursos | Falta implementar | No localizado | Puede resolverse con posiciones y rutas SVG narrativas. |
-| Datos geográficos reales | Fuera del alcance de la beta | No hay PostGIS ni datasets activos | No son necesarios para validar el producto ciudadano. |
-| MapLibre / Turf / PostGIS | Pospuesto | Documentación técnica | Se reconsiderará solo si una fase posterior necesita territorio real. |
+| SVG de inspección | Existe y es aprovechable | Prototipo preventivo | Buena base para hotspots. |
+| Territorio ilustrado/SVG | Falta implementar | Decisión de producto | Solución oficial para la beta. |
+| Estados invierno–verano del territorio | Falta implementar | No localizado | El mismo territorio debe mostrar prevención y consecuencias posteriores. |
+| Capas narrativas | Falta implementar | No localizado | Zonas, carreteras, infraestructuras, población y recursos. |
+| Perímetro de incendio | Falta implementar | No localizado | Resolver con geometrías SVG predefinidas y estados. |
+| Movimiento de recursos | Falta implementar | No localizado | Resolver mediante posiciones y rutas narrativas SVG. |
+| Datos geográficos reales | Fuera del alcance de la beta | Sin PostGIS ni datasets | No son necesarios para validar el aprendizaje. |
+| MapLibre / Turf / PostGIS | Fuera del alcance de la beta | Documentación técnica | Reconsiderar solo en una fase posterior. |
 
 ## 6. Contenidos editoriales e internacionalización
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Contenidos separados parcialmente | Existe y es aprovechable | `src/content/scenarios/`, `campaign.ts` | Los escenarios están fuera de la interfaz. |
-| Plantilla i18n de escenarios | Existe y es aprovechable | `src/content/i18n/es/scenarios.ts` | Permite editar textos sin alterar la estructura del escenario. |
-| Script de extracción | Existe y es aprovechable | `scripts/extract-scenario-i18n.ts` | Facilita regenerar catálogo editorial. |
-| Guía de revisión de textos | Existe y es aprovechable | `docs/revision-textos/` | Útil para revisión no técnica. |
-| Fuente única de verdad editorial | Existe, pero necesita revisión | Escenarios base + catálogo i18n + documentos de revisión | Debe definirse qué archivo manda y cómo se sincroniza. |
-| Codificación de caracteres | Existe, pero necesita revisión | Se observan textos con `?` o sin tildes | Requiere limpieza UTF-8 y pruebas. |
-| Segundo idioma | Falta implementar | Solo catálogo español | La arquitectura lo permite, pero no hay otra traducción. |
+| Escenarios externos a la vista | Existe y es aprovechable | `src/content/scenarios/` | Buena base para edición modular. |
+| Catálogo i18n español | Existe y es aprovechable | `src/content/i18n/es/scenarios.ts` | Permite separar textos de estructura. |
+| Script de extracción | Existe y es aprovechable | `scripts/extract-scenario-i18n.ts` | Debe preservarse. |
+| Documentos de revisión | Existe y es aprovechable | `docs/revision-textos/` | Útiles para revisión editorial no técnica. |
+| Fuente única de verdad | Existe, pero necesita revisión | Escenarios, i18n y Markdown | Sigue pendiente decidir qué archivo manda. |
+| Codificación UTF-8 | Existe, pero necesita revisión | Textos sin tildes o dañados | Requiere limpieza y pruebas automáticas. |
+| Segundo idioma | Fuera del alcance de la beta | Solo español | No es prioritario para Vertical Beta 1. |
 
 ## 7. Recursos gráficos e iconografía
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Imágenes principales | Existe y es aprovechable | `public/images/operational-command-hero.png`, `gameplay-wildfire-scene.png`, `primer-aviso-humo.png` | Funcionan como fondos y apoyo visual. |
-| Avatares | Existe y es aprovechable | Tres PNG de perfil forestal | Integrados como rutas HTTP. |
-| Iconografía funcional | Existe, pero necesita revisión | Emojis y símbolos embebidos | No constituye una familia visual propia ni accesible. |
-| Sistema de iconos SVG | Falta implementar | No localizado | Debe coordinarse con el territorio ilustrado/SVG. |
-| Gestión de assets | Existe, pero necesita revisión | Rutas individuales en Fastify | Conviene servir `public` de forma estática y documentar licencias/origen. |
-| Licencias y atribución | Falta implementar | No localizado | Debe registrarse para publicación. |
+| Imágenes principales | Existe y es aprovechable | `public/images/` | Funcionan como apoyo visual y referencia. |
+| Avatares | Existe y es aprovechable | Tres PNG | Ya están integrados. |
+| Iconografía funcional | Existe, pero necesita revisión | Emojis y símbolos | No constituye una familia final ni accesible. |
+| Sistema de iconos SVG | Falta implementar | No localizado | Debe coordinarse con el territorio ilustrado. |
+| Gestión de assets | Existe, pero necesita revisión | Rutas individuales Fastify | Servir `public` de forma estática y documentar origen. |
+| Licencias y atribución | Falta implementar | No localizado | Necesario antes de publicación. |
 
 ## 8. Backend, API y datos
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Servidor Fastify | Existe y es aprovechable | `src/interfaces/http/server.ts`, `app.ts` | Es la base técnica oficial de la beta. |
-| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript y decisión de arquitectura | Debe modularizar motor, interfaz, contenido y servicios sin migración de framework. |
+| Servidor Fastify | Existe y es aprovechable | `server.ts`, `app.ts` | Base técnica oficial. |
+| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript | Modularizar motor, interfaz, contenido y servicios. |
 | Healthcheck | Existe y es aprovechable | `/health` | Básico y funcional. |
 | Endpoint de contenido | Existe y es aprovechable | `/game-content/data` | Entrega variables, escenarios y campaña. |
-| Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Usa datos de ejemplo de Madrid y Sevilla, desconectados del juego. |
-| Persistencia en PostgreSQL/PostGIS | Fuera del alcance de la beta | No hay Prisma ni dependencia PostgreSQL | No es necesaria para la beta inicial. |
-| Redis y bus de eventos | Pospuesto | Especificación backend | No son necesarios para la siguiente fase. |
-| OpenAPI y contratos | Falta implementar | Backlog pendiente | Solo será prioritario para endpoints que formen parte estable del producto. |
-| Autenticación y usuarios | Falta implementar | No localizado | No necesaria para la beta local, sí para cuentas o informes centralizados. |
+| Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Datos de ejemplo desconectados del juego. |
+| Persistencia PostgreSQL/PostGIS | Fuera del alcance de la beta | No implementada | No necesaria para la primera beta. |
+| Redis y bus de eventos | Fuera del alcance de la beta | Solo documentación | No necesarios. |
+| Autenticación y cuentas | Fuera del alcance de la beta | No implementadas | No necesarias para una beta sin usuarios registrados. |
 
 ## 9. Pruebas y calidad
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Vitest configurado | Existe y es aprovechable | `package.json` | Script disponible. |
-| Tests unitarios | Falta implementar o no localizados | No se localizaron archivos de prueba en la revisión | Debe verificarse con listado completo local y añadir cobertura del motor. |
-| Tests de integración HTTP | Falta implementar o no localizados | No localizados | Prioridad para endpoints y carga de contenido. |
-| Tests end-to-end | Falta implementar | No Playwright/Cypress activo | Necesarios para la ruta vertical. |
-| Typecheck y build | Existe y es aprovechable | Scripts `typecheck` y `build` | No se ha verificado su ejecución en esta auditoría remota. |
-| CI | Falta implementar o no activo | El commit revisado no tiene estados de CI | Debe configurarse GitHub Actions. |
-| Cobertura | Es solo documentación o propuesta | Objetivo >80% en docs | No hay informe disponible. |
+| Vitest configurado | Existe y es aprovechable | `package.json` | Base para pruebas. |
+| Tests unitarios del motor | Falta implementar o no localizados | No localizados | Prioridad al extraer la lógica. |
+| Tests de integración HTTP | Falta implementar o no localizados | No localizados | Cubrir contenido, inicio y rutas principales. |
+| Tests end-to-end | Falta implementar | No Playwright activo | Cubrir al menos dos partidas preventivas diferentes. |
+| Typecheck y build | Existe y es aprovechable | Scripts disponibles | Deben ejecutarse en CI. |
+| CI | Falta implementar | Sin checks activos verificados | Añadir GitHub Actions para typecheck, build y tests. |
+| Validación del objetivo educativo | Falta implementar | No existe protocolo | Comprobar que el usuario entiende la relación prevención–impacto. |
 
 ## 10. Despliegue y operación
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Ejecución local | Existe y es aprovechable | `npm run dev`, `npm run build`, `npm start` | Base suficiente para desarrollo. |
-| Despliegue de una aplicación Fastify | Falta implementar | Decisión de arquitectura | Debe elegirse un proveedor compatible y evitar separar frontend/backend en la beta. |
-| Railway + Vercel | Necesita revisión | `docs/analysis/gaps-and-decisions.md` | Vercel deja de ser necesario si se mantiene una sola aplicación Fastify. |
-| Docker | Falta implementar o no localizado | No localizado | Puede no ser necesario en la siguiente fase. |
-| Entornos y secretos | Es solo documentación o propuesta | Documentación DevOps | No hay infraestructura real verificada. |
-| Observabilidad | Falta implementar | Fastify usa log básico, sin métricas ni trazas | No prioritaria hasta estabilizar el MVP. |
-| Publicación automatizada | Falta implementar | Sin CI/CD activo verificado | Debe añadirse cuando exista una rama estable de producto. |
+| Ejecución local | Existe y es aprovechable | Scripts npm | Base suficiente para desarrollo. |
+| Despliegue de una app Fastify | Falta implementar | Decisión técnica | Elegir un proveedor compatible con una única aplicación. |
+| Separación Railway + Vercel | Fuera del alcance de la beta | Documentación previa | No es necesaria al mantener una sola aplicación. |
+| Docker | No prioritario | No localizado | Evaluar solo si facilita el despliegue elegido. |
+| Publicación automatizada | Falta implementar | Sin CI/CD activo | Incorporar después de estabilizar la rama. |
 
-## 11. Documentación y gestión del proyecto
+## 11. Documentación y gestión
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Índice documental | Existe y es aprovechable | `docs/README.md` | Buena navegación general. |
-| Especificaciones por área | Existe y es aprovechable | `docs/product`, `architecture`, `frontend`, `backend`, etc. | Cobertura amplia. |
-| Backlog documental | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa que la decisión actual. |
-| Gaps y riesgos | Existe y es aprovechable | `docs/analysis/gaps-and-decisions.md` | Ya reconoce sobreingeniería y falta de implementación. |
-| Documentación histórica | Existe, pero necesita revisión | `docs/legacy`, `buzon`, manuales | Mucho valor editorial, pero mezcla material vigente, propuesta y archivo. |
-| Issues y pull requests como gestión | Falta estructurar | El backlog no está trasladado a Issues | Debe hacerse después de aprobar este inventario. |
-| Criterios de terminado | Es solo documentación o propuesta | Plantillas y guías | Falta aplicarlos a entregables reales. |
+| Índice documental | Existe y es aprovechable | `docs/README.md` | Buena navegación. |
+| Inventario actual | Existe y es aprovechable | Este documento | Debe mantenerse vivo tras cada decisión de alcance. |
+| Especificación Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Define el producto inicial oficial. |
+| Backlog previo | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa. |
+| Material histórico | Existe, pero necesita revisión | `docs/legacy`, `buzon` | Separar vigente, referencia y archivo. |
+| Issues como gestión | Falta estructurar | Backlog aún documental | Crear después de cerrar decisiones pendientes. |
+| Criterios de terminado | Es solo documentación o propuesta | Plantillas | Aplicarlos a los próximos hitos. |
 
 ---
 
@@ -174,68 +226,42 @@ La prioridad no debería ser añadir más arquitectura ni más pantallas, sino c
 
 1. **Marca:** `¡Apaga las llamas!`.
 2. **Público principal:** ciudadanía.
-3. **Arquitectura:** mantener y modularizar la aplicación Fastify.
-4. **Mapa:** territorio ilustrado/SVG para la beta.
-5. **Motor:** reglas narrativas y heurísticas explicables.
+3. **Objetivo educativo:** mostrar el impacto de la prevención sobre la emergencia posterior.
+4. **Producto inicial:** Vertical Beta 1 en dos momentos conectados, invierno y verano.
+5. **Arquitectura:** mantener y modularizar Fastify.
+6. **Mapa:** territorio ilustrado/SVG.
+7. **Motor:** reglas narrativas y heurísticas explicables.
+8. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
 
 ## Decisiones aún pendientes antes del roadmap
 
-1. **Producto inicial:** recorrido exacto de la beta dentro del material existente.
-2. **Objetivo educativo:** aprendizaje ciudadano prioritario y criterios para evaluarlo.
-3. **Fuente editorial:** archivos de escenario, catálogo i18n o documentos Markdown.
-4. **Dominio:** forma concreta de extraer el motor actual a módulos TypeScript y retirar o integrar el dominio de incidentes de ejemplo.
-5. **Publicación:** formato de explotación y despliegue inicial.
-
-## Elementos que conviene conservar
-
-- Catálogo tipado de escenarios.
-- Pantallas preventivas con hotspots, límites y consecuencias diferidas.
-- Balance preventivo y primer aviso.
-- Ruta de crisis con acciones limitadas.
-- Endpoint único de contenido.
-- Página de playtest editorial.
-- Catálogo i18n y documentos de revisión.
-- Variables y fórmula inicial de resultado.
-- Imágenes de referencia y avatares.
-- Documentación de riesgos y decisiones.
-
-## Elementos que conviene revisar o simplificar
-
-- Arquitectura hexagonal + DDD + CQRS completa para el tamaño actual.
-- Next.js, Redis, RabbitMQ y PostGIS antes de validar el juego.
-- Duplicidad entre campaña estacional y ruta vertical narrativa.
-- Dos modelos de dominio desconectados.
-- Archivos de interfaz de miles de líneas.
-- Textos duplicados y problemas de codificación.
-- Uso de emojis como iconografía final.
-- Endpoint de incendios de ejemplo sin relación con el producto.
-- Referencias documentales a `Guardián del Bosque`.
+1. **Fuente editorial:** escenarios TypeScript, catálogo i18n o documentos Markdown como fuente principal.
+2. **Dominio:** diseño concreto de los módulos del motor y retirada o integración del dominio de incidentes de ejemplo.
+3. **Publicación:** formato de explotación y proveedor inicial.
+4. **Validación:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
 
 ## Vacíos prioritarios
 
-1. Cerrar el recorrido exacto y objetivo educativo de la beta ciudadana.
-2. Extraer el motor del archivo de interfaz a módulos TypeScript dentro de Fastify.
-3. Crear pruebas del motor y del recorrido vertical.
-4. Documentar el grafo real de escenas y dependencias.
-5. Resolver la fuente única de verdad editorial.
-6. Diseñar e implementar el territorio ilustrado/SVG.
-7. Añadir persistencia local y reanudación.
-8. Crear un informe final causal más completo.
-9. Convertir el backlog aprobado en GitHub Issues.
-10. Configurar CI básico: typecheck, build y tests.
+1. Fijar los IDs exactos de las escenas de la Vertical Beta 1.
+2. Documentar el grafo narrativo completo invierno–verano.
+3. Definir el contrato de estado heredado entre fases.
+4. Extraer el motor a módulos TypeScript.
+5. Crear pruebas que comparen partidas con prevención distinta.
+6. Resolver la fuente única de verdad editorial.
+7. Diseñar el territorio ilustrado/SVG con estados estacionales.
+8. Añadir persistencia local.
+9. Crear un informe final causal completo.
+10. Configurar CI básico.
 
 ## Recomendación de siguiente hito
 
-El siguiente hito debería ser **consolidar una beta vertical ciudadana, jugable y mantenible** con este alcance:
+El siguiente hito debe convertir la Vertical Beta 1 acordada en una **especificación funcional ejecutable**:
 
-- Un recorrido completo de prevención, primer aviso, crisis y resultado.
-- Motor TypeScript separado de la vista y ejecutado dentro de Fastify.
-- Reglas narrativas y heurísticas explicables.
-- Contenido externo y editable.
-- Territorio ilustrado/SVG con estados vinculados a decisiones.
-- Persistencia local.
-- Resultado causal basado en decisiones.
-- Pruebas unitarias e integración.
-- Interfaz actual refactorizada sin migración de framework.
+- escena por escena;
+- variables que hereda el verano;
+- condiciones y consecuencias;
+- contenido que se conserva;
+- contenido que queda fuera;
+- criterios de aceptación y pruebas.
 
-MapLibre, PostGIS, Next.js, Redis y una simulación física o celular quedan fuera de la beta. Solo se reconsiderarán después de validar el producto con ciudadanía y demostrar una necesidad concreta.
+No debe iniciarse una migración de framework ni una simulación geoespacial avanzada antes de completar y validar ese recorrido.

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -29,6 +29,8 @@ La **Vertical Beta 1** queda definida como una partida ciudadana completa en dos
 
 El aprendizaje central es comprobar que la prevención cambia el margen operativo, los daños, la exposición de la población y la dificultad de las decisiones posteriores.
 
+La gobernanza editorial queda dividida en tres responsabilidades: los escenarios TypeScript mandan sobre estructura y reglas; el catálogo i18n español manda sobre los textos publicados; y los documentos Markdown sirven para revisión y aprobación, pero no alimentan directamente el juego.
+
 ---
 
 ## 1. Producto y alcance
@@ -154,11 +156,12 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Escenarios externos a la vista | Existe y es aprovechable | `src/content/scenarios/` | Buena base para edición modular. |
-| Catálogo i18n español | Existe y es aprovechable | `src/content/i18n/es/scenarios.ts` | Permite separar textos de estructura. |
-| Script de extracción | Existe y es aprovechable | `scripts/extract-scenario-i18n.ts` | Debe preservarse. |
-| Documentos de revisión | Existe y es aprovechable | `docs/revision-textos/` | Útiles para revisión editorial no técnica. |
-| Fuente única de verdad | Existe, pero necesita revisión | Escenarios, i18n y Markdown | Sigue pendiente decidir qué archivo manda. |
+| Escenarios TypeScript | Existe y es aprovechable | `src/content/scenarios/` | Son la fuente de verdad de estructura, IDs, opciones, impactos, requisitos, flags, desbloqueos y transiciones. |
+| Catálogo i18n español | Existe y es aprovechable | `src/content/i18n/es/scenarios.ts` | Es la fuente de verdad de los textos publicados: títulos, contexto, preguntas, feedback y piezas narrativas. |
+| Documentos Markdown de revisión | Existe y es aprovechable | `docs/revision-textos/` | Son el espacio de revisión, comentarios y aprobación editorial; no constituyen una fuente ejecutable del juego. |
+| Script de extracción | Existe, pero necesita revisión | `scripts/extract-scenario-i18n.ts` | No debe sobrescribir el catálogo aprobado. Debe generar una base nueva, detectar campos ausentes o validar sincronización. |
+| Flujo editorial combinado | Existe y es aprovechable | Decisión de producto | TypeScript gobierna reglas; i18n gobierna textos; Markdown documenta revisión y aprobación. |
+| Sincronización y trazabilidad | Falta implementar | No hay automatización completa | Añadir validaciones para detectar IDs o campos desalineados y registrar qué revisión Markdown se ha incorporado al catálogo. |
 | Codificación UTF-8 | Existe, pero necesita revisión | Textos sin tildes o dañados | Requiere limpieza y pruebas automáticas. |
 | Segundo idioma | Fuera del alcance de la beta | Solo español | No es prioritario para Vertical Beta 1. |
 
@@ -197,6 +200,7 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Typecheck y build | Existe y es aprovechable | Scripts disponibles | Deben ejecutarse en CI. |
 | CI | Falta implementar | Sin checks activos verificados | Añadir GitHub Actions para typecheck, build y tests. |
 | Validación del objetivo educativo | Falta implementar | No existe protocolo | Comprobar que el usuario entiende la relación prevención–impacto. |
+| Validación editorial automatizada | Falta implementar | No localizada | Comprobar IDs, claves i18n, textos ausentes y divergencias antes de integrar cambios. |
 
 ## 10. Despliegue y operación
 
@@ -231,14 +235,14 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 5. **Arquitectura:** mantener y modularizar Fastify.
 6. **Mapa:** territorio ilustrado/SVG.
 7. **Motor:** reglas narrativas y heurísticas explicables.
-8. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
+8. **Fuente editorial:** TypeScript para estructura y reglas; catálogo i18n para textos publicados; Markdown para revisión y aprobación.
+9. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
 
 ## Decisiones aún pendientes antes del roadmap
 
-1. **Fuente editorial:** escenarios TypeScript, catálogo i18n o documentos Markdown como fuente principal.
-2. **Dominio:** diseño concreto de los módulos del motor y retirada o integración del dominio de incidentes de ejemplo.
-3. **Publicación:** formato de explotación y proveedor inicial.
-4. **Validación:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
+1. **Dominio:** diseño concreto de los módulos del motor y retirada o integración del dominio de incidentes de ejemplo.
+2. **Publicación:** formato de explotación y proveedor inicial.
+3. **Validación:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
 
 ## Vacíos prioritarios
 
@@ -247,11 +251,12 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 3. Definir el contrato de estado heredado entre fases.
 4. Extraer el motor a módulos TypeScript.
 5. Crear pruebas que comparen partidas con prevención distinta.
-6. Resolver la fuente única de verdad editorial.
-7. Diseñar el territorio ilustrado/SVG con estados estacionales.
-8. Añadir persistencia local.
-9. Crear un informe final causal completo.
-10. Configurar CI básico.
+6. Adaptar el script y el flujo editorial para proteger el catálogo i18n aprobado.
+7. Añadir validaciones de sincronización entre escenarios, i18n y documentos de revisión.
+8. Diseñar el territorio ilustrado/SVG con estados estacionales.
+9. Añadir persistencia local.
+10. Crear un informe final causal completo.
+11. Configurar CI básico.
 
 ## Recomendación de siguiente hito
 

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -1,0 +1,231 @@
+# Inventario actual del proyecto
+
+Fecha de revisión: 26 de julio de 2026  
+Repositorio revisado: `rakadie/juegoincendio`  
+Rama base: `main`
+
+## Criterios de clasificación
+
+- **Existe y es aprovechable**: implementado o suficientemente definido para reutilizarse.
+- **Existe, pero necesita revisión**: hay una base útil, aunque presenta deuda, inconsistencias o falta de validación.
+- **Es solo documentación o propuesta**: está descrito, pero no materializado en el producto.
+- **Falta implementar**: no se ha localizado una implementación funcional en la rama revisada.
+
+## Resumen ejecutivo
+
+El repositorio contiene tres capas de avance distintas:
+
+1. **Documentación extensa de producto y arquitectura**, con visión, dominio, frontend, backend, datos, testing, DevOps y gobierno del proyecto.
+2. **Contenido editorial estructurado**, con alrededor de cincuenta escenarios, variables, impactos, decisiones, textos revisables e internacionalización inicial.
+3. **Un prototipo vertical funcional**, servido por Fastify y construido dentro de una única página HTML/JavaScript, con prevención, primer aviso, crisis, decisiones, variables, resultados y reinicio.
+
+El producto ya supera el estado de maqueta estática. Sin embargo, la arquitectura objetivo documentada —Next.js, React, Zustand, MapLibre, PostgreSQL/PostGIS, Redis, CQRS completo y despliegue distribuido— no está implementada. El juego funcional actual vive principalmente dentro de `src/interfaces/http/prototype-page.ts`, mientras que el dominio TypeScript separado solo cubre un ejemplo mínimo de incidentes activos.
+
+La prioridad no debería ser añadir más arquitectura ni más pantallas, sino consolidar la beta vertical existente: separar motor, interfaz y contenido; definir el alcance real del MVP; eliminar duplicidades; añadir pruebas; y decidir qué partes de la arquitectura objetivo son necesarias ahora.
+
+---
+
+## 1. Producto y alcance
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Concepto de serious game sobre incendios | Existe y es aprovechable | `README.md`, `docs/product/vision-and-scope.md` | La propuesta de valor está formulada. |
+| Bucle prevención → crisis → resultado | Existe y es aprovechable | `src/content/campaign.ts`, `prototype-page.ts` | Ya hay una beta vertical navegable. |
+| Público objetivo | Existe, pero necesita revisión | `docs/product/vision-and-scope.md` | Mezcla gestores, estudiantes y ciudadanía. Hay que elegir un público principal para el MVP. |
+| Objetivo educativo | Existe, pero necesita revisión | Documentación de producto y escenarios | Conviven formación técnica, sensibilización ciudadana y divulgación. Debe priorizarse uno. |
+| Nombre e identidad del producto | Existe, pero necesita revisión | `Guardián del Bosque` en documentación y `¡Apaga las llamas!` en interfaz | Hay dos nombres de producto. Debe decidirse marca principal y posible subtítulo. |
+| Alcance del MVP | Es solo documentación o propuesta | Varias especificaciones | Hay propuestas diferentes: ciclo estacional, beta de comunicación, prevención y simulación geoespacial. Falta cerrar un único alcance. |
+| KPIs | Es solo documentación o propuesta | `docs/product/vision-and-scope.md` | No hay analítica implementada. |
+| Modelo de publicación y explotación | Falta implementar | No localizado | Debe definirse si será demostrador, producto educativo, licencia institucional o publicación editorial. |
+
+## 2. Escenarios y narrativa
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Catálogo de escenarios | Existe y es aprovechable | `src/content/scenarios/index.ts` | Hay aproximadamente 50 escenarios agrupados por prevención, comunicación y operaciones. |
+| Tipado común de escenarios | Existe y es aprovechable | `src/domain/types/scenario.ts` | Incluye opciones, impactos, requisitos, desbloqueos, acciones, combinaciones y resultados. |
+| Ruta vertical de comunicación | Existe y es aprovechable | `CRISIS_ROUTE_MODULE`, escenarios de comunicación | Tiene selección limitada de acciones, métricas y transición entre escenas. |
+| Pantallas preventivas | Existe y es aprovechable | `src/content/prevention-inspections.ts` | Hay hotspots, acciones, límites, flags, combinaciones y consecuencias diferidas. |
+| Primer aviso y balance preventivo | Existe y es aprovechable | `src/content/prevention-balance.ts` y documentación asociada | Conecta las decisiones preventivas con la crisis. |
+| Árbol narrativo global | Existe, pero necesita revisión | `nextLogic`, `routeLogic`, campaña | Hay ramificación parcial, pero no un grafo único y documentado de toda la experiencia. |
+| Coherencia de IDs, nombres y categorías | Existe, pero necesita revisión | Historial de renombrados y archivos eliminados | Conviene validar duplicados, saltos de numeración y escenarios huérfanos. |
+| Validación experta | Falta implementar | No localizada como proceso cerrado | Hay notas de fuentes, pero no consta aprobación formal por especialistas. |
+| Versionado editorial | Existe, pero necesita revisión | `docs/revision-textos/`, `src/content/i18n/` | Buena base, aunque hay caracteres dañados y duplicidad entre textos fuente y plantilla. |
+
+## 3. Motor de juego y dominio
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Estado de partida | Existe y es aprovechable | `buildInitialState()` en `prototype-page.ts` | Registra fases, recursos, terreno, inspecciones, crisis y resultado. |
+| Aplicación de impactos y límites | Existe y es aprovechable | `applyVector`, métricas de inspección y crisis | Ya existen reglas operativas simples. |
+| Condiciones y transiciones | Existe y es aprovechable | `parseConditionExpression`, `scenarioNextStep`, `routeConditionMatches` | Hay evaluación de condiciones declarativas. |
+| Resultados dinámicos | Existe y es aprovechable | `finalizeCampaignResult()` | Calcula protección, daños, confianza y capacidad operativa. |
+| Reinicio de partida | Existe y es aprovechable | `buildInitialState()` y botón de reinicio | Funcional en memoria. |
+| Persistencia de partida | Falta implementar | No localizada | No hay `localStorage`, base de datos ni sincronización. |
+| Motor desacoplado de la interfaz | Falta implementar | La lógica principal está embebida en `prototype-page.ts` | Debe extraerse a módulos TypeScript testeables. |
+| Dominio separado de incidentes | Existe, pero necesita revisión | `FireIncident`, repositorio en memoria, query handler | Es un ejemplo aislado y no gobierna la partida real. Debe integrarse o retirarse. |
+| Simulación geoespacial / propagación | Es solo documentación o propuesta | Arquitectura, dominio y backlog | No hay grilla, autómata celular ni cálculo espacial implementado. |
+| Eventos de dominio auditables | Es solo documentación o propuesta | `docs/domain/game-design-spec.md` | La interfaz guarda logs, pero no existe un event store o modelo de eventos de dominio. |
+
+## 4. Interfaz y experiencia de usuario
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Prototipo web navegable | Existe y es aprovechable | `/` y `/prototype`, `prototype-page.ts` | Incluye seis etapas, decisiones y resultados. |
+| Playtest de escenarios | Existe y es aprovechable | `/game-content`, `game-content-page.ts` | Herramienta útil para revisar contenidos de forma aislada. |
+| Diseño responsive inicial | Existe y es aprovechable | Media queries en ambas páginas | Hay adaptación a tablet y móvil. |
+| Accesibilidad inicial | Existe, pero necesita revisión | Foco visible, diálogo, reducción de movimiento | Falta auditoría WCAG, semántica completa y pruebas con teclado/lector. |
+| Componentización | Falta implementar | HTML, CSS y JS concentrados en dos archivos grandes | Debe dividirse por componentes y responsabilidades. |
+| Sistema de diseño reutilizable | Es solo documentación o propuesta | Mockups e iconografía, estilos embebidos | No hay tokens ni componentes compartidos. |
+| Claridad de información | Existe, pero necesita revisión | Mucha información y textos largos | Necesita prueba de usabilidad y jerarquía por fase. |
+| Estados de carga y error | Existe y es aprovechable | `contentStatus`, `contentError` | Implementación básica. |
+| Sonido y narrativa audiovisual | Falta implementar en esta versión | No localizado en la rama revisada | Puede existir en prototipos históricos, pero no en la beta actual. |
+
+## 5. Mapa y territorio
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Representación visual del territorio | Existe, pero necesita revisión | SVG de inspección e imagen de crisis | Sirve para prototipo, no para simulación territorial. |
+| Hotspots interactivos | Existe y es aprovechable | `prevention-inspections.ts` y SVG de interfaz | Buena base para decisiones localizadas. |
+| Capas cartográficas | Falta implementar | No hay MapLibre ni GeoJSON operativo | Documentado, pero no materializado. |
+| Perímetro dinámico del incendio | Falta implementar | No localizado | El fuego cambia como métricas, no como geometría. |
+| Movimiento de recursos | Falta implementar | No localizado | No hay rutas, posiciones ni tiempos espaciales. |
+| Datos geográficos reales | Falta implementar | No hay PostGIS ni datasets activos | Debe decidirse si el MVP necesita territorio real o ficticio. |
+| MapLibre / Turf | Es solo documentación o propuesta | `docs/frontend/frontend-spec.md` | No aparece en dependencias ni código actual. |
+
+## 6. Contenidos editoriales e internacionalización
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Contenidos separados parcialmente | Existe y es aprovechable | `src/content/scenarios/`, `campaign.ts` | Los escenarios están fuera de la interfaz. |
+| Plantilla i18n de escenarios | Existe y es aprovechable | `src/content/i18n/es/scenarios.ts` | Permite editar textos sin alterar la estructura del escenario. |
+| Script de extracción | Existe y es aprovechable | `scripts/extract-scenario-i18n.ts` | Facilita regenerar catálogo editorial. |
+| Guía de revisión de textos | Existe y es aprovechable | `docs/revision-textos/` | Útil para revisión no técnica. |
+| Fuente única de verdad editorial | Existe, pero necesita revisión | Escenarios base + catálogo i18n + documentos de revisión | Debe definirse qué archivo manda y cómo se sincroniza. |
+| Codificación de caracteres | Existe, pero necesita revisión | Se observan textos con `?` o sin tildes | Requiere limpieza UTF-8 y pruebas. |
+| Segundo idioma | Falta implementar | Solo catálogo español | La arquitectura lo permite, pero no hay otra traducción. |
+
+## 7. Recursos gráficos e iconografía
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Imágenes principales | Existe y es aprovechable | `public/images/operational-command-hero.png`, `gameplay-wildfire-scene.png`, `primer-aviso-humo.png` | Funcionan como fondos y apoyo visual. |
+| Avatares | Existe y es aprovechable | Tres PNG de perfil forestal | Integrados como rutas HTTP. |
+| Iconografía funcional | Existe, pero necesita revisión | Emojis y símbolos embebidos | No constituye una familia visual propia ni accesible. |
+| Sistema de iconos SVG | Falta implementar | No localizado | Debe crearse si se mantiene la dirección visual propuesta. |
+| Gestión de assets | Existe, pero necesita revisión | Rutas individuales en Fastify | Conviene servir `public` de forma estática y documentar licencias/origen. |
+| Licencias y atribución | Falta implementar | No localizado | Debe registrarse para publicación. |
+
+## 8. Backend, API y datos
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Servidor Fastify | Existe y es aprovechable | `src/interfaces/http/server.ts`, `app.ts` | Sirve prototipo, contenido e imágenes. |
+| Healthcheck | Existe y es aprovechable | `/health` | Básico y funcional. |
+| Endpoint de contenido | Existe y es aprovechable | `/game-content/data` | Entrega variables, escenarios y campaña. |
+| Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Usa datos de ejemplo de Madrid y Sevilla, desconectados del juego. |
+| Persistencia en PostgreSQL/PostGIS | Falta implementar | No hay Prisma ni dependencia PostgreSQL | Solo documentación. |
+| Redis y bus de eventos | Es solo documentación o propuesta | Especificación backend | No implementados. |
+| OpenAPI y contratos | Falta implementar | Backlog pendiente | No se localizaron contratos ejecutables. |
+| Autenticación y usuarios | Falta implementar | No localizado | No necesaria para la beta local, sí para cuentas o informes centralizados. |
+
+## 9. Pruebas y calidad
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Vitest configurado | Existe y es aprovechable | `package.json` | Script disponible. |
+| Tests unitarios | Falta implementar o no localizados | No se localizaron archivos de prueba en la revisión | Debe verificarse con listado completo local y añadir cobertura del motor. |
+| Tests de integración HTTP | Falta implementar o no localizados | No localizados | Prioridad para endpoints y carga de contenido. |
+| Tests end-to-end | Falta implementar | No Playwright/Cypress activo | Necesarios para la ruta vertical. |
+| Typecheck y build | Existe y es aprovechable | Scripts `typecheck` y `build` | No se ha verificado su ejecución en esta auditoría remota. |
+| CI | Falta implementar o no activo | El commit revisado no tiene estados de CI | Debe configurarse GitHub Actions. |
+| Cobertura | Es solo documentación o propuesta | Objetivo >80% en docs | No hay informe disponible. |
+
+## 10. Despliegue y operación
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Ejecución local | Existe y es aprovechable | `npm run dev`, `npm run build`, `npm start` | Base suficiente para desarrollo. |
+| Railway + Vercel | Es solo documentación o propuesta | `docs/analysis/gaps-and-decisions.md` | La implementación actual es una única app Fastify, no frontend/backend separados. |
+| Docker | Falta implementar o no localizado | No localizado | Puede no ser necesario en la siguiente fase. |
+| Entornos y secretos | Es solo documentación o propuesta | Documentación DevOps | No hay infraestructura real verificada. |
+| Observabilidad | Falta implementar | Fastify usa log básico, sin métricas ni trazas | No prioritaria hasta estabilizar el MVP. |
+| Publicación automatizada | Falta implementar | Sin CI/CD activo verificado | Debe añadirse cuando exista una rama estable de producto. |
+
+## 11. Documentación y gestión del proyecto
+
+| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+|---|---|---|---|
+| Índice documental | Existe y es aprovechable | `docs/README.md` | Buena navegación general. |
+| Especificaciones por área | Existe y es aprovechable | `docs/product`, `architecture`, `frontend`, `backend`, etc. | Cobertura amplia. |
+| Backlog documental | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa que el prototipo actual. |
+| Gaps y riesgos | Existe y es aprovechable | `docs/analysis/gaps-and-decisions.md` | Ya reconoce sobreingeniería y falta de implementación. |
+| Documentación histórica | Existe, pero necesita revisión | `docs/legacy`, `buzon`, manuales | Mucho valor editorial, pero mezcla material vigente, propuesta y archivo. |
+| Issues y pull requests como gestión | Falta estructurar | No hay PR recientes y el backlog no está trasladado a Issues | Debe hacerse después de aprobar este inventario. |
+| Criterios de terminado | Es solo documentación o propuesta | Plantillas y guías | Falta aplicarlos a entregables reales. |
+
+---
+
+## Contradicciones y decisiones que deben resolverse antes del roadmap
+
+1. **Marca:** `Guardián del Bosque` frente a `¡Apaga las llamas!`.
+2. **Público principal:** gestores, estudiantes o ciudadanía.
+3. **Producto inicial:** ciclo estacional completo, newsgame narrativo o simulador técnico.
+4. **Arquitectura:** mantener una aplicación Fastify modular o migrar ya a Next.js + backend separado.
+5. **Mapa:** territorio ilustrado/SVG para la beta o MapLibre/PostGIS desde el principio.
+6. **Motor:** reglas narrativas y heurísticas explicables o simulación celular geoespacial.
+7. **Fuente editorial:** archivos de escenario, catálogo i18n o documentos Markdown.
+8. **Dominio:** integrar el prototipo actual en módulos TypeScript o desarrollar el dominio DDD documentado desde cero.
+
+## Elementos que conviene conservar
+
+- Catálogo tipado de escenarios.
+- Pantallas preventivas con hotspots, límites y consecuencias diferidas.
+- Balance preventivo y primer aviso.
+- Ruta de crisis con acciones limitadas.
+- Endpoint único de contenido.
+- Página de playtest editorial.
+- Catálogo i18n y documentos de revisión.
+- Variables y fórmula inicial de resultado.
+- Imágenes de referencia y avatares.
+- Documentación de riesgos y decisiones.
+
+## Elementos que conviene revisar o simplificar
+
+- Arquitectura hexagonal + DDD + CQRS completa para el tamaño actual.
+- Next.js, Redis, RabbitMQ, PostGIS y microcapas antes de validar el juego.
+- Duplicidad entre campaña estacional y ruta vertical narrativa.
+- Dos modelos de dominio desconectados.
+- Archivos de interfaz de miles de líneas.
+- Textos duplicados y problemas de codificación.
+- Uso de emojis como iconografía final.
+- Endpoint de incendios de ejemplo sin relación con el producto.
+
+## Vacíos prioritarios
+
+1. Definir el MVP y su público principal.
+2. Extraer el motor del archivo de interfaz.
+3. Crear pruebas del motor y del recorrido vertical.
+4. Documentar el grafo real de escenas y dependencias.
+5. Resolver la fuente única de verdad editorial.
+6. Añadir persistencia local y reanudación.
+7. Crear un informe final causal más completo.
+8. Decidir el nivel de mapa necesario para la beta.
+9. Convertir el backlog aprobado en GitHub Issues.
+10. Configurar CI básico: typecheck, build y tests.
+
+## Recomendación de siguiente hito
+
+No iniciar todavía la migración a Next.js/PostGIS.
+
+El siguiente hito debería ser **consolidar una beta vertical jugable y mantenible** con este alcance:
+
+- Un recorrido completo de prevención, primer aviso, crisis y resultado.
+- Motor TypeScript separado de la vista.
+- Contenido externo y editable.
+- Persistencia local.
+- Resultado causal basado en decisiones.
+- Pruebas unitarias e integración.
+- Interfaz actual refactorizada sin rediseño total.
+
+Solo después de probar esa beta con usuarios y validar la necesidad territorial debería decidirse si se incorpora MapLibre/PostGIS y un backend persistente.


### PR DESCRIPTION
## Qué cambia

Añade `docs/project/inventario-actual.md` con una revisión estructurada del estado real del repositorio.

## Alcance

- Producto y alcance
- Escenarios y narrativa
- Motor de juego y dominio
- Interfaz y UX
- Mapa y territorio
- Contenidos e internacionalización
- Recursos gráficos
- Backend y datos
- Pruebas y calidad
- Despliegue
- Documentación y gestión

Cada elemento se clasifica como aprovechable, pendiente de revisión, propuesta documental o falta de implementación.

## Objetivo

Disponer de una base común antes de definir el roadmap y trasladar tareas a GitHub Issues.

## Validación

Auditoría remota de la rama `main`. No se modifica código de producto.