### PR TITLE
docs: definir dominio ligero de partida

### DIFF
--- a/docs/architecture/decision-game-domain.md
+++ b/docs/architecture/decision-game-domain.md
@@ -1,0 +1,216 @@
+# Decisión arquitectónica: dominio del juego
+
+Fecha de decisión: 26 de julio de 2026  
+Estado: Aprobada para la Vertical Beta 1
+
+## Contexto
+
+El repositorio contiene actualmente dos modelos desconectados:
+
+1. Un dominio de ejemplo basado en `FireIncident`, coordenadas, estados de incendio, repositorio en memoria y el endpoint `/fires/active`.
+2. El dominio funcional real de la partida, actualmente incrustado en `src/interfaces/http/prototype-page.ts`, donde se gestionan el estado, las decisiones, los impactos, las condiciones, las transiciones y los resultados.
+
+También conviven dos modelos de contenido parcialmente duplicados:
+
+- `CampaignNode`, específico y sencillo para los nodos de invierno y verano.
+- `Scenario`, más completo y capaz de representar requisitos, opciones, impactos, flags, acciones, combinaciones, resultados y navegación.
+
+La Vertical Beta 1 necesita una arquitectura mantenible, explicable y comprobable, sin introducir DDD, CQRS o infraestructura innecesaria antes de validar el producto.
+
+## Decisión
+
+Adoptar un **dominio ligero centrado en la partida**, representado por una entidad o agregado `GameSession` —o su equivalente en español, `Partida`—.
+
+El incendio no será el centro del dominio. El centro será la experiencia completa del jugador y la relación causal entre prevención de invierno y actuación de verano.
+
+## Modelo principal
+
+La sesión de juego deberá representar, como mínimo:
+
+```text
+GameSession
+├── progress
+│   ├── season
+│   ├── currentSceneId
+│   └── completedScenes
+├── prevention
+│   ├── decisions
+│   ├── metrics
+│   ├── strengths
+│   └── vulnerabilities
+├── inheritedState
+│   └── condiciones que pasan al verano
+├── emergency
+│   ├── resources
+│   ├── metrics
+│   ├── flags
+│   └── fireState
+├── history
+└── result
+```
+
+## Operaciones del dominio
+
+Las reglas se implementarán como funciones TypeScript puras y testeables. El diseño deberá cubrir operaciones equivalentes a:
+
+- `createGameSession()`
+- `applyDecision()`
+- `completeInspection()`
+- `calculatePreventionBalance()`
+- `transitionToSummer()`
+- `resolveScenario()`
+- `calculateFinalResult()`
+
+Los nombres definitivos pueden cambiar durante la implementación, pero las responsabilidades deben permanecer separadas de la interfaz.
+
+## Modelo unificado de escenas
+
+Se sustituirá progresivamente la duplicidad entre `CampaignNode` y `Scenario` por una unión tipada de escenas:
+
+```ts
+type GameScene =
+  | DecisionScene
+  | ActionSelectionScene
+  | InspectionScene
+  | SummaryScene
+  | RouteScene;
+```
+
+Todas las escenas compartirán una base equivalente a:
+
+```ts
+interface BaseScene {
+  id: string;
+  phase: 'winter' | 'transition' | 'summer' | 'result';
+  next?: SceneTransition[];
+}
+```
+
+Las inspecciones, balances y selectores de ruta pueden conservar estructuras específicas, pero deben participar en un flujo común y utilizar el mismo contrato de estado.
+
+## Función de `campaign.ts`
+
+`campaign.ts` dejará de duplicar textos, opciones e impactos. Su función será declarar el recorrido oficial de la Vertical Beta 1.
+
+Ejemplo orientativo:
+
+```ts
+export const VERTICAL_BETA_FLOW = [
+  'intro',
+  'winter-housing',
+  'winter-territory',
+  'winter-community',
+  'prevention-balance',
+  'first-alert',
+  'summer-escalation',
+  'summer-wind-change',
+  'summer-communication',
+  'summer-night',
+  'final-report'
+];
+```
+
+Los escenarios TypeScript seguirán siendo la fuente de verdad de las reglas y la estructura. El catálogo i18n seguirá siendo la fuente de verdad de los textos publicados.
+
+## Organización recomendada
+
+```text
+src/
+├── game/
+│   ├── domain/
+│   │   ├── game-session.ts
+│   │   ├── game-scene.ts
+│   │   ├── game-state.ts
+│   │   └── game-event.ts
+│   ├── rules/
+│   │   ├── apply-decision.ts
+│   │   ├── evaluate-condition.ts
+│   │   ├── calculate-prevention.ts
+│   │   ├── transition-to-summer.ts
+│   │   └── calculate-result.ts
+│   └── flow/
+│       └── vertical-beta-flow.ts
+├── content/
+├── interfaces/http/
+└── public/
+```
+
+Esta estructura es orientativa. Lo obligatorio es separar estado, reglas y flujo de las vistas HTTP.
+
+## Dominio de incidentes existente
+
+El dominio formado por:
+
+- `FireIncident`;
+- `FireIncidentRepository`;
+- `GetActiveFiresQueryHandler`;
+- `InMemoryFireIncidentRepository`;
+- endpoint `/fires/active`;
+
+se considera **código de ejemplo desconectado del producto**.
+
+La decisión es retirarlo de la beta, no integrarlo en el nuevo dominio. Representa incendios georreferenciados reales, mientras que la Vertical Beta 1 utiliza un territorio narrativo ilustrado/SVG.
+
+La retirada se realizará en una tarea de implementación posterior y deberá comprobar que ninguna ruta o prueba necesaria depende de esos elementos.
+
+## Fastify
+
+Fastify se mantiene como base de la aplicación.
+
+Fastify será responsable de:
+
+- servir la interfaz;
+- entregar contenido;
+- servir recursos estáticos;
+- exponer, cuando sea necesario, endpoints estables.
+
+Fastify no contendrá las reglas de la partida. Las rutas y vistas consumirán el dominio del juego.
+
+## Consecuencias positivas
+
+- La herencia invierno–verano queda representada explícitamente.
+- Las reglas pueden probarse sin navegador.
+- Se reduce la lógica incrustada en `prototype-page.ts`.
+- Se elimina la duplicidad entre modelos de campaña.
+- El informe final puede construirse desde un historial causal real.
+- Se mantiene una arquitectura proporcional al tamaño de la beta.
+
+## Costes y riesgos
+
+- Será necesario migrar gradualmente la lógica actual sin romper la beta.
+- Habrá que fijar un contrato único de métricas, flags y recursos.
+- Los escenarios actuales deberán adaptarse al modelo común.
+- La retirada del dominio de incidentes debe hacerse de forma controlada.
+- Durante la transición convivirán temporalmente código antiguo y nuevo.
+
+## Fuera de alcance
+
+Esta decisión no introduce:
+
+- DDD completo;
+- CQRS;
+- bus de eventos;
+- repositorios persistentes;
+- PostGIS;
+- simulación física o celular;
+- mapa geográfico real;
+- separación de frontend y backend.
+
+## Criterios de aceptación de la implementación futura
+
+1. El estado de partida tiene un contrato TypeScript único.
+2. Las decisiones de invierno producen un estado heredado explícito.
+3. Las escenas de verano consumen ese estado heredado.
+4. Las reglas principales pueden ejecutarse y probarse sin DOM.
+5. La interfaz no calcula directamente los resultados del juego.
+6. `campaign.ts` declara el flujo y no duplica contenido completo.
+7. Existe un único modelo común de escenas o una compatibilidad tipada claramente delimitada.
+8. El dominio de incidentes de ejemplo y `/fires/active` se retiran sin afectar la beta.
+9. Dos partidas con prevención distinta generan estados y resultados diferentes de forma reproducible.
+
+## Decisiones pendientes relacionadas
+
+- Fijar los IDs exactos de las escenas de la Vertical Beta 1.
+- Definir el contrato completo de métricas, recursos, flags y eventos.
+- Dividir la migración en Issues implementables.
+- Definir el plan de pruebas unitarias y de integración.

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -31,6 +31,8 @@ El aprendizaje central es comprobar que la prevención cambia el margen operativ
 
 La gobernanza editorial queda dividida en tres responsabilidades: los escenarios TypeScript mandan sobre estructura y reglas; el catálogo i18n español manda sobre los textos publicados; y los documentos Markdown sirven para revisión y aprobación, pero no alimentan directamente el juego.
 
+El dominio técnico oficial será ligero y estará centrado en una **`GameSession` o Partida**. Las reglas se extraerán de la interfaz a funciones TypeScript puras; los tipos de escena se unificarán progresivamente; `campaign.ts` declarará el flujo sin duplicar contenido; y el dominio de incendios activos con coordenadas se retirará por no formar parte de la experiencia narrativa de la beta.
+
 ---
 
 ## 1. Producto y alcance
@@ -45,7 +47,7 @@ La gobernanza editorial queda dividida en tres responsabilidades: los escenarios
 | Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Recorrido oficial cerrado para la siguiente fase. |
 | Duración objetivo | Existe, pero necesita validación | Definición de la beta | Referencia inicial: 20–25 minutos. Debe comprobarse con usuarios. |
 | KPIs | Es solo documentación o propuesta | Documentación de producto | Falta convertirlos en métricas concretas de validación. |
-| Modelo de publicación y explotación | Falta implementar | No localizado | Debe definirse en una fase posterior: demostrador, producto editorial o licencia institucional. |
+| Modelo de publicación y explotación | Falta implementar | Issue #9 | Debe definirse el formato inicial y el proveedor de despliegue. |
 
 ### Recorrido oficial de la Vertical Beta 1
 
@@ -105,25 +107,57 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Escenarios operativos de verano | Existe y es aprovechable | Escenarios `os-*` | Existe material suficiente para primer envío, escalado, viento, evacuación, noche y relevo. |
 | Ruta de comunicación | Existe y es aprovechable | `CRISIS_ROUTE_MODULE`, `cs-018`, `cs-023` | Aporta saturación del 112 y desinformación. |
 | Selección exacta de escenarios beta | Existe, pero necesita revisión | Vertical Beta 1 y catálogo | Debe fijarse el ID definitivo de cada escena y retirar duplicados. |
+| Modelo unificado de escenas | Es solo documentación o propuesta | `docs/architecture/decision-game-domain.md` | Crear una unión tipada para decisiones, inspecciones, resúmenes, rutas y selección de acciones. |
 | Grafo narrativo completo | Falta implementar | `nextLogic`, `routeLogic` parciales | Debe documentarse el flujo oficial y sus bifurcaciones. |
 | Coherencia de IDs y categorías | Existe, pero necesita revisión | Historial de renombrados | Hay que localizar duplicados, escenarios huérfanos y saltos de numeración. |
-| Validación experta | Falta implementar | No consta proceso cerrado | Debe revisarse el contenido operativo antes de publicación. |
+| Validación experta | Falta implementar | Issue #10 | Debe definirse quién revisa el contenido operativo y cómo queda aprobado. |
 
 ## 3. Motor de juego y dominio
 
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Estado de partida | Existe y es aprovechable | `buildInitialState()` | Registra fases, recursos, terreno, inspecciones, crisis y resultado. |
-| Aplicación de impactos | Existe y es aprovechable | `applyVector`, impactos de escenarios | Ya existen reglas heurísticas simples. |
-| Condiciones y transiciones | Existe y es aprovechable | `parseConditionExpression`, `scenarioNextStep` | Hay evaluación declarativa inicial. |
-| Herencia invierno–verano | Existe, pero necesita revisión | Balance y métricas agregadas | Es el núcleo del producto y debe formalizarse en un único contrato de estado. |
-| Resultados dinámicos | Existe y es aprovechable | `finalizeCampaignResult()` | Calcula protección, daños, confianza y capacidad operativa. |
+| Estado de partida actual | Existe y es aprovechable | `buildInitialState()` | Registra fases, recursos, terreno, inspecciones, crisis y resultado. Debe migrarse al contrato `GameSession`. |
+| Dominio ligero centrado en `GameSession` | Es solo documentación o propuesta | `docs/architecture/decision-game-domain.md` | Es la arquitectura oficial para la beta y debe implementarse sin DDD/CQRS innecesarios. |
+| Aplicación de impactos | Existe y es aprovechable | `applyVector`, impactos de escenarios | Debe extraerse como regla TypeScript pura y testeable. |
+| Condiciones y transiciones | Existe y es aprovechable | `parseConditionExpression`, `scenarioNextStep` | Deben extraerse a un evaluador común de condiciones. |
+| Herencia invierno–verano | Existe, pero necesita revisión | Balance y métricas agregadas | Debe formalizarse como `inheritedState` dentro de la partida. |
+| Resultados dinámicos | Existe y es aprovechable | `finalizeCampaignResult()` | Debe migrarse a una regla de dominio que calcule el resultado desde el estado real. |
 | Informe causal | Existe, pero necesita revisión | Resultado y logs actuales | Debe explicar qué decisión preventiva causó o evitó cada consecuencia relevante. |
-| Persistencia de partida | Falta implementar | No localizada | Añadir `localStorage` para reanudar la beta. |
-| Motor separado de la interfaz | Falta implementar | Lógica embebida en `prototype-page.ts` | Extraer a módulos TypeScript testeables dentro de Fastify. |
-| Dominio de incidentes de ejemplo | Existe, pero necesita revisión | `FireIncident` y repositorio en memoria | Está desconectado del juego; debe integrarse o retirarse. |
-| Motor narrativo y heurístico | Existe, pero necesita revisión | Variables, impactos y condiciones | Es la dirección oficial. Debe documentarse y probarse. |
+| Flujo oficial de la beta | Es solo documentación o propuesta | `campaign.ts` y decisión de dominio | `campaign.ts` debe declarar orden y bifurcaciones sin repetir textos, opciones ni impactos. |
+| Persistencia de partida | Falta implementar | No localizada | Añadir `localStorage` sobre un estado serializable de `GameSession`. |
+| Motor separado de la interfaz | Falta implementar | Lógica embebida en `prototype-page.ts` | Extraer dominio, reglas y flujo a módulos TypeScript antes de rediseñar la interfaz. |
+| Dominio de incidentes de ejemplo | Existe, pero necesita revisión | `FireIncident`, repositorio y query handler | La decisión es retirarlo: no representa la partida ni el territorio narrativo de la beta. |
+| Motor narrativo y heurístico | Existe, pero necesita revisión | Variables, impactos y condiciones | Es la dirección oficial. Debe documentarse, implementarse como reglas puras y probarse. |
 | Simulación física o celular | Fuera del alcance de la beta | Documentación avanzada | No se implementará en Vertical Beta 1. |
+
+### Módulos de dominio acordados
+
+```text
+src/game/
+├── domain/
+│   ├── game-session.ts
+│   ├── game-scene.ts
+│   ├── game-state.ts
+│   └── game-event.ts
+├── rules/
+│   ├── apply-decision.ts
+│   ├── evaluate-condition.ts
+│   ├── calculate-prevention.ts
+│   ├── transition-to-summer.ts
+│   └── calculate-result.ts
+└── flow/
+    └── vertical-beta-flow.ts
+```
+
+Operaciones principales previstas:
+
+- `createGameSession()`
+- `applyDecision()`
+- `completeInspection()`
+- `calculatePreventionBalance()`
+- `transitionToSummer()`
+- `resolveScenario()`
+- `calculateFinalResult()`
 
 ## 4. Interfaz y experiencia de usuario
 
@@ -134,7 +168,7 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Responsive inicial | Existe y es aprovechable | Media queries | Requiere validación real en móvil y escritorio. |
 | Accesibilidad inicial | Existe, pero necesita revisión | Foco, diálogo, reducción de movimiento | Falta auditoría WCAG y pruebas completas con teclado. |
 | Distinción visual invierno–verano | Existe, pero necesita revisión | Etapas actuales | Debe reforzarse sin romper la continuidad causal. |
-| Componentización | Falta implementar | Dos archivos de interfaz muy grandes | Separar vistas, componentes, estado y eventos. |
+| Componentización | Falta implementar | Dos archivos de interfaz muy grandes | Separar vistas, componentes, estado y eventos después de extraer el motor. |
 | Sistema de diseño | Es solo documentación o propuesta | Estilos embebidos y referencias visuales | Crear tokens y componentes reutilizables. |
 | Claridad informativa | Existe, pero necesita revisión | Textos largos y alta densidad | Jerarquizar contexto, decisión, consecuencias y ayuda. |
 | Sonido | Falta implementar en la versión actual | No localizado | Secundario frente al motor y al recorrido. |
@@ -181,10 +215,10 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
 | Servidor Fastify | Existe y es aprovechable | `server.ts`, `app.ts` | Base técnica oficial. |
-| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript | Modularizar motor, interfaz, contenido y servicios. |
+| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript y decisión de dominio | Fastify servirá vistas y contenido, pero no contendrá las reglas del juego. |
 | Healthcheck | Existe y es aprovechable | `/health` | Básico y funcional. |
-| Endpoint de contenido | Existe y es aprovechable | `/game-content/data` | Entrega variables, escenarios y campaña. |
-| Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Datos de ejemplo desconectados del juego. |
+| Endpoint de contenido | Existe y es aprovechable | `/game-content/data` | Entrega variables, escenarios y campaña. Debe adaptarse al flujo y tipos unificados. |
+| Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Se retirará junto con el dominio `FireIncident`, al ser código de ejemplo desconectado de la beta. |
 | Persistencia PostgreSQL/PostGIS | Fuera del alcance de la beta | No implementada | No necesaria para la primera beta. |
 | Redis y bus de eventos | Fuera del alcance de la beta | Solo documentación | No necesarios. |
 | Autenticación y cuentas | Fuera del alcance de la beta | No implementadas | No necesarias para una beta sin usuarios registrados. |
@@ -194,12 +228,12 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
 | Vitest configurado | Existe y es aprovechable | `package.json` | Base para pruebas. |
-| Tests unitarios del motor | Falta implementar o no localizados | No localizados | Prioridad al extraer la lógica. |
+| Tests unitarios del motor | Falta implementar o no localizados | No localizados | Cubrir cada regla pura del nuevo dominio. |
 | Tests de integración HTTP | Falta implementar o no localizados | No localizados | Cubrir contenido, inicio y rutas principales. |
 | Tests end-to-end | Falta implementar | No Playwright activo | Cubrir al menos dos partidas preventivas diferentes. |
 | Typecheck y build | Existe y es aprovechable | Scripts disponibles | Deben ejecutarse en CI. |
 | CI | Falta implementar | Sin checks activos verificados | Añadir GitHub Actions para typecheck, build y tests. |
-| Validación del objetivo educativo | Falta implementar | No existe protocolo | Comprobar que el usuario entiende la relación prevención–impacto. |
+| Validación del objetivo educativo | Falta implementar | Issue #10 | Comprobar que el usuario entiende la relación prevención–impacto. |
 | Validación editorial automatizada | Falta implementar | No localizada | Comprobar IDs, claves i18n, textos ausentes y divergencias antes de integrar cambios. |
 
 ## 10. Despliegue y operación
@@ -207,7 +241,7 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Elemento | Clasificación | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
 | Ejecución local | Existe y es aprovechable | Scripts npm | Base suficiente para desarrollo. |
-| Despliegue de una app Fastify | Falta implementar | Decisión técnica | Elegir un proveedor compatible con una única aplicación. |
+| Despliegue de una app Fastify | Falta implementar | Issue #9 | Elegir un proveedor compatible con una única aplicación. |
 | Separación Railway + Vercel | Fuera del alcance de la beta | Documentación previa | No es necesaria al mantener una sola aplicación. |
 | Docker | No prioritario | No localizado | Evaluar solo si facilita el despliegue elegido. |
 | Publicación automatizada | Falta implementar | Sin CI/CD activo | Incorporar después de estabilizar la rama. |
@@ -219,14 +253,15 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Índice documental | Existe y es aprovechable | `docs/README.md` | Buena navegación. |
 | Inventario actual | Existe y es aprovechable | Este documento | Debe mantenerse vivo tras cada decisión de alcance. |
 | Especificación Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Define el producto inicial oficial. |
+| Decisión de dominio del juego | Existe y es aprovechable | `docs/architecture/decision-game-domain.md` | Define el dominio ligero centrado en partida y el plan de retirada del código de ejemplo. |
 | Backlog previo | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa. |
 | Material histórico | Existe, pero necesita revisión | `docs/legacy`, `buzon` | Separar vigente, referencia y archivo. |
-| Issues como gestión | Falta estructurar | Backlog aún documental | Crear después de cerrar decisiones pendientes. |
+| Issues como gestión | Existe, pero necesita revisión | Issues #9 y #10 | Ya se registran decisiones diferidas; falta trasladar el roadmap técnico cuando se apruebe. |
 | Criterios de terminado | Es solo documentación o propuesta | Plantillas | Aplicarlos a los próximos hitos. |
 
 ---
 
-## Decisiones de producto resueltas
+## Decisiones de producto y arquitectura resueltas
 
 1. **Marca:** `¡Apaga las llamas!`.
 2. **Público principal:** ciudadanía.
@@ -236,37 +271,46 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 6. **Mapa:** territorio ilustrado/SVG.
 7. **Motor:** reglas narrativas y heurísticas explicables.
 8. **Fuente editorial:** TypeScript para estructura y reglas; catálogo i18n para textos publicados; Markdown para revisión y aprobación.
-9. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
+9. **Dominio:** modelo ligero centrado en `GameSession`; reglas TypeScript puras; escenas unificadas; `campaign.ts` como flujo; retirada de `FireIncident` y `/fires/active`.
+10. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
 
 ## Decisiones aún pendientes antes del roadmap
 
-1. **Dominio:** diseño concreto de los módulos del motor y retirada o integración del dominio de incidentes de ejemplo.
-2. **Publicación:** formato de explotación y proveedor inicial.
-3. **Validación:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
+1. **Publicación — Issue #9:** formato de explotación y proveedor inicial.
+2. **Validación — Issue #10:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
+
+Estas decisiones están registradas como incidencias y no bloquean la especificación ni la implementación inicial del dominio del juego.
 
 ## Vacíos prioritarios
 
 1. Fijar los IDs exactos de las escenas de la Vertical Beta 1.
 2. Documentar el grafo narrativo completo invierno–verano.
-3. Definir el contrato de estado heredado entre fases.
-4. Extraer el motor a módulos TypeScript.
-5. Crear pruebas que comparen partidas con prevención distinta.
-6. Adaptar el script y el flujo editorial para proteger el catálogo i18n aprobado.
-7. Añadir validaciones de sincronización entre escenarios, i18n y documentos de revisión.
-8. Diseñar el territorio ilustrado/SVG con estados estacionales.
-9. Añadir persistencia local.
-10. Crear un informe final causal completo.
-11. Configurar CI básico.
+3. Definir el contrato serializable de `GameSession` y del estado heredado entre fases.
+4. Crear los módulos `domain`, `rules` y `flow` acordados.
+5. Unificar progresivamente `Scenario`, `CampaignNode`, inspecciones, balances y rutas bajo tipos de escena comunes.
+6. Convertir `campaign.ts` en la declaración del flujo oficial sin contenido duplicado.
+7. Retirar `FireIncident`, su repositorio, query handler y `/fires/active`.
+8. Extraer de `prototype-page.ts` la aplicación de impactos, condiciones, transición estacional y cálculo de resultados.
+9. Crear pruebas que comparen partidas con prevención distinta.
+10. Adaptar el script y el flujo editorial para proteger el catálogo i18n aprobado.
+11. Añadir validaciones de sincronización entre escenarios, i18n y documentos de revisión.
+12. Diseñar el territorio ilustrado/SVG con estados estacionales.
+13. Añadir persistencia local.
+14. Crear un informe final causal completo.
+15. Configurar CI básico.
 
 ## Recomendación de siguiente hito
 
-El siguiente hito debe convertir la Vertical Beta 1 acordada en una **especificación funcional ejecutable**:
+El siguiente hito debe convertir la Vertical Beta 1 acordada en una **especificación funcional ejecutable y un dominio mínimo testeable**:
 
 - escena por escena;
+- contrato de `GameSession`;
 - variables que hereda el verano;
 - condiciones y consecuencias;
+- tipos comunes de escena;
+- flujo oficial de la campaña;
 - contenido que se conserva;
 - contenido que queda fuera;
 - criterios de aceptación y pruebas.
 
-No debe iniciarse una migración de framework ni una simulación geoespacial avanzada antes de completar y validar ese recorrido.
+No debe iniciarse una migración de framework, un rediseño integral de interfaz ni una simulación geoespacial avanzada antes de completar y validar ese núcleo.


### PR DESCRIPTION
## Qué cambia

Documenta la decisión arquitectónica para la Vertical Beta 1 y actualiza el inventario general del proyecto.

## Archivos

- `docs/architecture/decision-game-domain.md`
- `docs/project/inventario-actual.md`

## Decisión

- El dominio se centra en `GameSession` o `Partida`.
- Las reglas se extraen a funciones TypeScript puras y testeables.
- Se unifica progresivamente el modelo de escenas.
- `campaign.ts` pasa a declarar el flujo oficial sin duplicar contenido.
- Fastify se mantiene como servidor, pero no contiene las reglas del juego.
- El dominio de `FireIncident` y `/fires/active` se considera código de ejemplo y se retirará en una tarea posterior.

## Inventario

- El dominio deja de figurar como decisión pendiente.
- Se actualizan motor, backend, documentación y vacíos prioritarios.
- Las únicas decisiones generales pendientes quedan vinculadas a los issues #9 y #10.

## Alcance

Esta PR solo guarda y alinea la decisión. No modifica código de producto ni elimina todavía componentes existentes.

## Validación

Revisión documental basada en la estructura actual del repositorio y en las decisiones de producto ya aprobadas.