### PR TITLE
docs: alinear fuentes de producto con el catálogo canónico

### DIFF
--- a/docs/product/vertical-beta-1-catalog.md
+++ b/docs/product/vertical-beta-1-catalog.md
@@ -2,14 +2,13 @@
 
 Fecha: 28 de julio de 2026  
 Issue: #23  
-Rama: `docs/vertical-beta-1-catalog`  
 Estado contrastado: `main@d08db13fd9330ba297d8b92ca8a77cce7e35aef3`  
 Implementación posterior: #67  
 Milestone de implementación: **M2 — Motor modular** (`#2`)
 
 ## 1. Propósito y alcance formal
 
-Este documento publica y valida el **catálogo objetivo** de la Vertical Beta 1. Es la fuente de verdad de M1 para:
+Este documento es la fuente de verdad de M1 para:
 
 - IDs canónicos;
 - orden y fases;
@@ -22,17 +21,15 @@ Este documento publica y valida el **catálogo objetivo** de la Vertical Beta 1.
 - clasificación completa de las 51 escenas;
 - desviaciones entre la especificación aprobada y el runtime auditado.
 
-La incidencia #23 se considera una **entrega documental de M1**. No exige que `main` implemente todavía el catálogo. La implementación física de IDs, payload, inspecciones, flujo, renderer, resultado e i18n se traslada a #67 y a sus tareas #68–#76.
+#23 es una **entrega documental de M1**. No afirma que `main` implemente ya el catálogo. La implementación física de IDs, payload, inspecciones, flujo, renderer, resultado e i18n se traslada a #67 y a sus tareas #68–#76.
 
-La validación de #23 significa:
+La validación documental significa:
 
-1. que los nodos objetivo están definidos de forma única;
-2. que cada unidad tiene fuente y posición;
-3. que las salidas del **grafo objetivo** solo apuntan a IDs canónicos oficiales;
-4. que toda desviación del runtime queda registrada y enlazada a implementación;
-5. que el documento puede utilizarse como entrada estable de #14 sin esperar a M2.
-
-No significa que el runtime auditado cumpla ya el grafo.
+1. los nodos objetivo están definidos de forma única;
+2. cada unidad tiene fuente y posición;
+3. las salidas del grafo objetivo solo apuntan a IDs canónicos oficiales;
+4. toda desviación del runtime queda registrada y enlazada a implementación;
+5. el documento puede utilizarse como entrada estable de #14 sin esperar a M2.
 
 ## 2. Principio causal
 
@@ -59,7 +56,7 @@ Reglas:
 - un nodo compartido conserva un único ID;
 - los resultados calculados son variantes del mismo nodo final;
 - no se reutilizan IDs retirados;
-- migración atómica y sin alias ejecutables.
+- migración atómica y sin aliases ejecutables.
 
 Fases:
 
@@ -97,7 +94,7 @@ intro-briefing-mission
 crisis-decision-emergency-fuel-break
 → crisis-decision-ravine-fire
 → crisis-decision-housing-defense
-→ ending-result-causal-report [contained]
+→ ending-result-causal-report
 ```
 
 ### Rama vulnerable
@@ -106,27 +103,34 @@ crisis-decision-emergency-fuel-break
 crisis-decision-access-blockage
 → crisis-decision-ravine-fire
 → crisis-decision-crown-fire
-→ ending-result-causal-report [overwhelmed]
+→ ending-result-causal-report
 ```
 
-`contained` y `overwhelmed` son resultados calculados, no IDs independientes.
+Existe un único nodo terminal. `contained` y `overwhelmed` son variantes calculadas dentro de `ending-result-causal-report`, no IDs independientes ni salidas fijadas por el router.
+
+La variante final se calcula desde `GameSession`, `inheritedState`, las decisiones de crisis y el historial causal. Las partidas de referencia esperan:
+
+- recorrido preparado → `contained`;
+- recorrido vulnerable → `overwhelmed`.
+
+Estas expectativas pertenecen a los fixtures de aceptación. Los daños parciales y las correcciones durante la crisis se expresan en el informe causal sin crear una tercera variante terminal.
 
 ## 5. Tabla definitiva
 
 | Posición | Fase | Rama | Unidad actual | ID canónico | Tipo | Fuente actual | Dependencias de entrada | Estado editorial | Destino en `campaign.ts` / flujo | Salidas canónicas |
 |---:|---|---|---|---|---|---|---|---|---|---|
-| 1 | `intro` | Común | Briefing hardcodeado | `intro-briefing-mission` | `briefing` | `src/interfaces/http/prototype-page.ts` | Inicio de sesión | `beta-oficial`; migrar a nodo declarativo | Añadir como nodo inicial; retirar texto y navegación hardcodeados | `prevention-inspection-territory-fuel` |
-| 2 | `prevention` | Común | `p-002-fincas-vegetacion-combustible` | `prevention-inspection-territory-fuel` | `inspection` | `src/content/prevention-inspections.ts` | `intro-briefing-mission` | `beta-oficial`; reducir | Primera entrada de `preventionInspections` | `prevention-inspection-housing-interface` |
-| 3 | `prevention` | Común | `p-001-viviendas-interfaz` | `prevention-inspection-housing-interface` | `inspection` | `src/content/prevention-inspections.ts` | `prevention-inspection-territory-fuel` | `beta-oficial`; reducir | Segunda entrada de `preventionInspections` | `transition-summary-prevention` |
-| 4 | `transition` | Común | `balance-prevencion` | `transition-summary-prevention` | `summary` | `src/content/prevention-balance.ts` | Dos inspecciones completadas | `beta-oficial`; reorientar | Mantener como `preventionBalance` | `crisis-decision-first-alert` |
-| 5 | `crisis` | Común | `s-040-primer-aviso-incendio` | `crisis-decision-first-alert` | `decision` | `src/content/prevention-balance.ts` | `transition-summary-prevention` | `beta-oficial`; conservar función | Mantener como `firstAlert` | `crisis-router-causal-map` |
-| 6 | `crisis` | Común | `m-001-apertura-tres-frentes` | `crisis-router-causal-map` | `router` | `src/content/prevention-balance.ts` | Primer aviso resuelto + estado heredado calculado | `beta-oficial`; reescribir | Mantener como `crisisRouteModule`; solo dos rutas automáticas | `crisis-decision-emergency-fuel-break`<br>`crisis-decision-access-blockage` |
-| 7A | `crisis` | Preparada | `s-025-cortafuego-emergencia` | `crisis-decision-emergency-fuel-break` | `decision` | `src/content/scenarios/operaciones/os-025-cortafuego-emergencia.ts` | Rama preparada + oportunidad de ataque | `beta-oficial`; conservar | Referenciar desde el flujo oficial; no duplicar contenido en `campaign.ts` | `crisis-decision-ravine-fire` |
-| 7B | `crisis` | Vulnerable | `s-011-corte-carretera-acceso` | `crisis-decision-access-blockage` | `decision` | `src/content/scenarios/operaciones/os-011-corte-carretera-acceso.ts` | Rama vulnerable + accesibilidad insuficiente | `beta-oficial`; conservar | Referenciar desde el flujo oficial; no duplicar contenido en `campaign.ts` | `crisis-decision-ravine-fire` |
-| 8 | `crisis` | Ambas | `s-027-fuego-en-barranco` | `crisis-decision-ravine-fire` | `decision` | `src/content/scenarios/operaciones/os-027-fuego-en-barranco.ts` | Una de las dos escenas de apertura completada | `beta-oficial`; conservar compartida | Referenciar una sola vez desde el flujo; comportamiento condicionado por estado heredado | `crisis-decision-housing-defense`<br>`crisis-decision-crown-fire` |
-| 9A | `crisis` | Preparada | `s-026-defensa-operativa-nucleo-viviendas` | `crisis-decision-housing-defense` | `decision` | `src/content/scenarios/operaciones/os-026-defensa-operativa-nucleo-viviendas.ts` | Barranco + rama preparada | `beta-oficial`; conservar | Referenciar desde la salida preparada del flujo | `ending-result-causal-report` |
-| 9B | `crisis` | Vulnerable | `s-030-fuego-de-copas` | `crisis-decision-crown-fire` | `decision` | `src/content/scenarios/operaciones/os-030-fuego-de-copas.ts` | Barranco + rama vulnerable | `beta-oficial`; conservar | Referenciar desde la salida vulnerable del flujo | `ending-result-causal-report` |
-| 10 | `ending` | Común | `resultado-beta` y resultado hardcodeado | `ending-result-causal-report` | `result` | `src/interfaces/http/prototype-page.ts` | `crisis-decision-housing-defense` o `crisis-decision-crown-fire` | `beta-oficial`; sustituir sentinela | Añadir como nodo terminal declarativo y retirar mecanismos duplicados | — |
+| 1 | `intro` | Común | Briefing hardcodeado | `intro-briefing-mission` | `briefing` | `src/interfaces/http/prototype-page.ts` | Inicio de sesión | `beta-oficial`; migrar | Nodo inicial declarativo | `prevention-inspection-territory-fuel` |
+| 2 | `prevention` | Común | `p-002-fincas-vegetacion-combustible` | `prevention-inspection-territory-fuel` | `inspection` | `src/content/prevention-inspections.ts` | `intro-briefing-mission` | `beta-oficial`; reducir | Primera inspección | `prevention-inspection-housing-interface` |
+| 3 | `prevention` | Común | `p-001-viviendas-interfaz` | `prevention-inspection-housing-interface` | `inspection` | `src/content/prevention-inspections.ts` | `prevention-inspection-territory-fuel` | `beta-oficial`; reducir | Segunda inspección | `transition-summary-prevention` |
+| 4 | `transition` | Común | `balance-prevencion` | `transition-summary-prevention` | `summary` | `src/content/prevention-balance.ts` | Dos inspecciones completadas | `beta-oficial`; reorientar | Resumen preventivo | `crisis-decision-first-alert` |
+| 5 | `crisis` | Común | `s-040-primer-aviso-incendio` | `crisis-decision-first-alert` | `decision` | `src/content/prevention-balance.ts` | `transition-summary-prevention` | `beta-oficial`; conservar función | Entrada común de crisis | `crisis-router-causal-map` |
+| 6 | `crisis` | Común | `m-001-apertura-tres-frentes` | `crisis-router-causal-map` | `router` | `src/content/prevention-balance.ts` | Primer aviso + estado heredado | `beta-oficial`; reescribir | Router automático de dos ramas | `crisis-decision-emergency-fuel-break`<br>`crisis-decision-access-blockage` |
+| 7A | `crisis` | Preparada | `s-025-cortafuego-emergencia` | `crisis-decision-emergency-fuel-break` | `decision` | `src/content/scenarios/operaciones/os-025-cortafuego-emergencia.ts` | Rama preparada | `beta-oficial`; conservar | Referencia desde flujo | `crisis-decision-ravine-fire` |
+| 7B | `crisis` | Vulnerable | `s-011-corte-carretera-acceso` | `crisis-decision-access-blockage` | `decision` | `src/content/scenarios/operaciones/os-011-corte-carretera-acceso.ts` | Rama vulnerable | `beta-oficial`; conservar | Referencia desde flujo | `crisis-decision-ravine-fire` |
+| 8 | `crisis` | Ambas | `s-027-fuego-en-barranco` | `crisis-decision-ravine-fire` | `decision` | `src/content/scenarios/operaciones/os-027-fuego-en-barranco.ts` | Escena de apertura completada | `beta-oficial`; compartida | Una sola definición condicionada por estado | `crisis-decision-housing-defense`<br>`crisis-decision-crown-fire` |
+| 9A | `crisis` | Preparada | `s-026-defensa-operativa-nucleo-viviendas` | `crisis-decision-housing-defense` | `decision` | `src/content/scenarios/operaciones/os-026-defensa-operativa-nucleo-viviendas.ts` | Barranco + rama preparada | `beta-oficial`; conservar | Salida preparada | `ending-result-causal-report` |
+| 9B | `crisis` | Vulnerable | `s-030-fuego-de-copas` | `crisis-decision-crown-fire` | `decision` | `src/content/scenarios/operaciones/os-030-fuego-de-copas.ts` | Barranco + rama vulnerable | `beta-oficial`; conservar | Salida vulnerable | `ending-result-causal-report` |
+| 10 | `ending` | Común | `resultado-beta` y resultado hardcodeado | `ending-result-causal-report` | `result` | `src/interfaces/http/prototype-page.ts` | Última decisión de crisis | `beta-oficial`; sustituir sentinela | Nodo terminal declarativo; calcula variante | — |
 
 El catálogo contiene **12 nodos funcionales únicos**. Cinco proceden de objetos `Scenario` actuales.
 
@@ -142,7 +146,7 @@ Cinco actuaciones candidatas; el jugador selecciona tres:
 4. activar pastoreo preventivo;
 5. evaluar una quema prescrita o línea preventiva profesional.
 
-Replantación y regulación general de quemas agrícolas no aparecen como decisiones independientes en el MVP.
+Replantación y regulación general de quemas agrícolas no aparecen como decisiones independientes.
 
 ### `prevention-inspection-housing-interface`
 
@@ -251,21 +255,17 @@ Total: **5 + 36 + 10 = 51**.
 Regla de carga objetivo:
 
 - solo `beta-oficial` entra en el payload y el flujo;
-- la biblioteca permanece en el repositorio, fuera del índice ejecutable;
+- la biblioteca permanece en el repositorio fuera del índice ejecutable;
 - el archivo no se carga ni recibe compatibilidad de runtime.
 
 ## 10. Alcance obligatorio de i18n
 
-La cobertura i18n obligatoria del producto comprende **los 12 nodos oficiales que contienen texto**, no únicamente los cinco objetos `Scenario`.
+La cobertura obligatoria comprende **los 12 nodos oficiales con texto**, no únicamente los cinco objetos `Scenario`.
 
-Se distinguen dos validaciones:
+1. Los cinco `Scenario` deben tener traducción completa y estricta.
+2. Briefing, dos inspecciones, resumen, primer aviso, router y resultado deben resolverse mediante contenido traducible.
 
-1. **Cobertura de escenas:** los cinco `Scenario` oficiales deben tener traducción completa y estricta en el catálogo de escenas.
-2. **Cobertura de flujo:** briefing, dos inspecciones, resumen, primer aviso, router y resultado deben resolverse mediante un catálogo de contenido traducible o mecanismo equivalente.
-
-El sistema final no debe aceptar fallback silencioso para un nodo oficial. La validación debe fallar cuando falte contenido obligatorio de cualquiera de los 12 IDs canónicos.
-
-La biblioteca candidata no necesita migrar ni completar i18n durante esta fase.
+El sistema final no debe aceptar fallback silencioso para un nodo oficial. La biblioteca candidata no necesita migrar ni completar i18n en esta fase.
 
 ## 11. Validación contra el commit auditado
 
@@ -277,62 +277,57 @@ main@d08db13fd9330ba297d8b92ca8a77cce7e35aef3
 
 | Comprobación | Resultado en el commit auditado |
 |---|---|
-| Los 12 IDs canónicos son únicos en la tabla | Correcto |
-| Las 51 escenas están clasificadas exactamente | Correcto: 5 oficiales, 36 de biblioteca y 10 históricas |
-| Las cinco escenas oficiales tienen fuente existente | Correcto |
-| Todas las unidades de la tabla tienen posición y dependencia | Correcto en este documento |
-| Todas las salidas objetivo enumeran IDs canónicos verificables | Correcto en este documento |
-| Los IDs canónicos existen en TypeScript | Pendiente: el código conserva IDs históricos |
-| El payload expone solo cinco `Scenario` | Incorrecto: expone los 51 |
+| Los 12 IDs canónicos son únicos | Correcto |
+| Las 51 escenas están clasificadas exactamente | Correcto: 5/36/10 |
+| Las fuentes declaradas existen | Correcto |
+| Las salidas usan IDs canónicos verificables | Correcto en este documento |
+| Los IDs canónicos existen en TypeScript | Pendiente |
+| El payload expone solo cinco `Scenario` | Incorrecto: expone 51 |
 | Solo se cargan dos inspecciones | Incorrecto: también se carga `p-003` |
-| `p-002` ofrece cinco candidatas y permite tres | Incorrecto: mantiene siete y permite cuatro |
-| `p-001` ofrece tres candidatas y permite dos | Incorrecto: mantiene siete y permite cuatro |
-| No se cargan nodos `invierno_*`/`verano_*` | Incorrecto: siguen en `CAMPAIGN_CONTENT` |
-| El primer aviso referencia solo contenido oficial | Incorrecto: desbloquea escenas excluidas |
-| El mapa solo representa las dos ramas aprobadas | Incorrecto: conserva comunicación, senderistas y población |
-| La rama se selecciona por estado causal | Incorrecto: `activeCrisisRoute()` fuerza `ruta-comunicacion` |
-| Briefing y resultado son declarativos | Incorrecto: siguen hardcodeados |
-| Las cinco escenas funcionan con el renderer actual | Incompatible: el renderer inicia solo `action-selection` y las elegidas son preguntas de opciones simples |
-| i18n cubre los 12 nodos oficiales | Incorrecto |
-| Falta de traducción produce error | Incorrecto: existe fallback silencioso |
+| `p-002` es 3 de 5 | Incorrecto: mantiene 4 de 7 |
+| `p-001` es 2 de 3 | Incorrecto: mantiene 4 de 7 |
+| No se cargan `invierno_*`/`verano_*` | Incorrecto |
+| El primer aviso referencia solo contenido oficial | Incorrecto |
+| El mapa representa solo dos ramas | Incorrecto |
+| La rama se selecciona por estado causal | Incorrecto: se fuerza `ruta-comunicacion` |
+| Briefing y resultado son declarativos | Incorrecto |
+| Las cinco escenas funcionan con el renderer actual | Incompatible |
+| i18n cubre los 12 nodos | Incorrecto |
+| La falta de traducción produce error | Incorrecto: fallback silencioso |
 | Existe prueba automática del catálogo | No localizada |
 
 ## 12. Desviaciones trasladadas a M2
 
-Toda implementación derivada de esta validación se centraliza en la épica:
-
-- #67 — **M2 — Implementar la Vertical Beta 1 ejecutable**.
-
-Tareas de la épica:
-
-- #68 — contrato común `GameScene` y validador del catálogo;
-- #69 — `GameSession`, eventos e invariantes;
-- #70 — dos inspecciones preventivas oficiales;
-- #71 — adaptación de las cinco escenas oficiales;
-- #72 — balance, flujo declarativo, router causal y resultado;
-- #73 — interfaz conectada al motor y renderers;
-- #74 — separación beta/biblioteca/archivo y retirada de campaña heredada;
-- #75 — migración atómica de IDs e i18n;
+- #67 — épica **M2 — Implementar la Vertical Beta 1 ejecutable**.
+- #68 — contrato `GameScene` y validador.
+- #69 — `GameSession`, eventos e invariantes.
+- #70 — dos inspecciones oficiales.
+- #71 — cinco escenas oficiales.
+- #72 — balance, flujo, router y resultado calculado.
+- #73 — interfaz conectada al motor.
+- #74 — separación beta/biblioteca/archivo.
+- #75 — migración atómica de IDs e i18n.
 - #76 — aceptación integral automatizada.
 
-Todas están asignadas al milestone GitHub **M2 — Motor modular** (`#2`). Permanecen fuera de `Ready` hasta que M1 complete sus puertas estructurales.
+Todas están asignadas al milestone **M2 — Motor modular** (`#2`).
 
 ## 13. Validaciones automatizables requeridas en M2
 
-Tras aplicar la migración, una prueba debe verificar:
+Una prueba debe verificar:
 
 1. 12 nodos funcionales oficiales;
 2. cinco `Scenario` ejecutables;
 3. dos inspecciones en el orden aprobado;
 4. unicidad global de IDs;
-5. existencia de las fuentes declaradas;
+5. existencia de fuentes;
 6. ausencia de referencias a biblioteca o archivo;
 7. ausencia de `invierno_*`, `verano_*` y `resultado-beta` en el payload;
-8. cobertura i18n estricta de los 12 nodos oficiales;
+8. cobertura i18n estricta de 12 nodos;
 9. una entrada y un terminal;
 10. ambas ramas alcanzables y convergentes;
-11. ausencia de nodos huérfanos y ciclos;
-12. uso compartido de `crisis-decision-ravine-fire` sin duplicación.
+11. ausencia de huérfanos y ciclos;
+12. barranco compartido sin duplicación;
+13. variante terminal calculada desde el estado final, no fijada por el router.
 
 Archivo orientativo:
 
@@ -340,21 +335,6 @@ Archivo orientativo:
 tests/vertical-beta-catalog.test.ts
 ```
 
-## 14. Criterio de cierre de #23
+## 14. Estado de la entrega
 
-#23 puede cerrarse como `completed` cuando:
-
-- este documento esté revisado;
-- la rama se integre en `main`;
-- `docs/README.md` lo enlace;
-- el cambio de alcance documental esté formalizado en GitHub;
-- #67 recoja las desviaciones técnicas;
-- el documento quede aprobado como entrada de #14.
-
-No es requisito de cierre de #23 que M2 haya implementado el runtime.
-
-Después del cierre de #23:
-
-- #13 puede cerrarse al quedar fijadas escenas e IDs;
-- #14 puede continuar sin esperar a M2;
-- #67 permanece fuera de `Ready` hasta que M1 complete sus puertas estructurales.
+#23 está completada y el catálogo está publicado en `main`. #13 quedó cerrado al fijarse escenas e IDs. #14 puede continuar sin esperar a M2.

--- a/docs/product/vertical-beta-1.md
+++ b/docs/product/vertical-beta-1.md
@@ -1,148 +1,177 @@
 # Vertical Beta 1 — ¡Apaga las llamas!
 
-Fecha de decisión: 26 de julio de 2026
+Fecha de decisión inicial: 26 de julio de 2026  
+Última consolidación: 28 de julio de 2026  
+Estado: **definición de producto vigente**
+
+## Fuente de verdad
+
+Este documento resume el producto aprobado. El catálogo, los IDs, las fuentes y las transiciones se definen de forma normativa en:
+
+- [`docs/product/vertical-beta-1-catalog.md`](vertical-beta-1-catalog.md);
+- #21 — convención canónica de IDs;
+- #22 — recorrido y tratamiento editorial;
+- #59 — aprobación del catálogo;
+- #66 — aprobación del modelo causal.
+
+Las revisiones anteriores de este documento que incluían tres inspecciones, tres estados preventivos, una ruta principal de comunicación o tres desenlaces quedan sustituidas por las decisiones citadas.
 
 ## Objetivo de producto
 
-Demostrar de forma comprensible para la ciudadanía que las decisiones tomadas durante el invierno modifican las condiciones, los recursos disponibles y las consecuencias de un incendio durante el verano.
+Demostrar que las decisiones preventivas sobre el territorio modifican el comportamiento posterior del fuego, la capacidad de intervención y las consecuencias del incendio.
 
-La beta no presenta invierno y verano como modos independientes. Son dos momentos de una misma partida:
+Eje causal:
 
-- **Invierno:** prevención.
-- **Verano:** actuación condicionada por la prevención.
+> prevención territorial → comportamiento del fuego → capacidad de extinción → consecuencias
 
-## Público principal
+La comunicación, el 112, la evacuación y la población vulnerable pueden aparecer como consecuencias o contenido complementario, pero no forman el núcleo causal del MVP.
 
-Ciudadanía.
+## Público y duración
 
-## Duración objetivo
+- Público principal: ciudadanía.
+- Duración objetivo: 20–25 minutos.
+- Partidas de referencia validadas: aproximadamente 20 y 21 minutos.
 
-20–25 minutos.
+## Flujo obligatorio
 
-## Fase 1 — Invierno: prevención
+### Tronco común
 
-### 1. Introducción y rol
+```text
+intro-briefing-mission
+→ prevention-inspection-territory-fuel
+→ prevention-inspection-housing-interface
+→ transition-summary-prevention
+→ crisis-decision-first-alert
+→ crisis-router-causal-map
+```
 
-- Presentación del municipio y del objetivo.
-- Elección de avatar.
-- Explicación breve del vínculo entre prevención y emergencia.
+El avatar es una preferencia opcional y no forma parte del flujo, del estado causal ni de los fixtures.
 
-### 2. Viviendas y edificios
+### Rama preparada
 
-- Inspección mediante hotspots.
-- Selección de cuatro actuaciones.
-- Decisiones sobre canalones, fachadas, vegetación, huecos, accesos y edificios de apoyo.
+```text
+crisis-decision-emergency-fuel-break
+→ crisis-decision-ravine-fire
+→ crisis-decision-housing-defense
+→ ending-result-causal-report
+```
 
-### 3. Fincas, vegetación y combustible
+### Rama vulnerable
 
-- Priorización de limpieza, accesos, quemas, pastoreo y vegetación.
-- Recursos y capacidad de intervención limitados.
+```text
+crisis-decision-access-blockage
+→ crisis-decision-ravine-fire
+→ crisis-decision-crown-fire
+→ ending-result-causal-report
+```
 
-### 4. Comunidad preparada
+`crisis-decision-ravine-fire` es un único nodo compartido. Su dificultad, opciones y consecuencias dependen del estado heredado.
 
-- Planes familiares.
-- Población vulnerable.
-- Canales oficiales.
-- Puntos de apoyo.
-- Información para visitantes y senderistas.
+## Prevención oficial
 
-### 5. Balance preventivo
+### Territorio y combustible
 
-El invierno termina con uno de estos estados:
+`prevention-inspection-territory-fuel` ofrece cinco actuaciones y permite seleccionar tres:
 
-- Municipio preparado.
-- Preparación desigual.
-- Territorio vulnerable.
+1. gestionar restos de poda;
+2. crear discontinuidades vegetales;
+3. limpiar márgenes de caminos rurales;
+4. activar pastoreo preventivo;
+5. evaluar una quema prescrita o línea preventiva profesional.
 
-## Estado que pasa al verano
+### Viviendas e interfaz
 
-La fase de verano debe heredar, como mínimo:
+`prevention-inspection-housing-interface` ofrece tres actuaciones y permite seleccionar dos:
 
-- Defensibilidad de viviendas.
-- Continuidad del combustible.
-- Accesibilidad.
-- Preparación familiar.
-- Población vulnerable identificada.
-- Confianza ciudadana.
-- Claridad de los canales oficiales.
-- Recursos disponibles.
-- Fortalezas y vulnerabilidades generadas por las decisiones.
+1. podar ramas bajas y retirar vegetación seca;
+2. separar copas;
+3. despejar accesos para autobombas.
 
-## Transición
+`p-003-comunidad-preparada` queda en la biblioteca candidata. No se carga ni se ejecuta en la Vertical Beta 1.
 
-Se declara un incendio. Antes de actuar, el juego muestra de manera explícita las condiciones heredadas del invierno y explica que la emergencia comienza con ese margen, no desde cero.
+## Estado heredado
 
-## Fase 2 — Verano: actuación
+La prevención se resume únicamente en cinco dimensiones causales:
 
-### 6. Primer aviso
+- `fuelLoad` — carga de combustible;
+- `fuelContinuity` — continuidad horizontal y vertical;
+- `operationalAccess` — accesos, maniobra y repliegue;
+- `defensibility` — capacidad de defensa territorial y de viviendas;
+- `attackOpportunity` — existencia de una oportunidad segura de ataque.
 
-- Verificar localización.
-- Movilizar medios.
-- Ordenar accesos.
-- Comunicar sin generar alarma innecesaria.
+Preparación familiar, población vulnerable, confianza ciudadana y canales oficiales no son dimensiones estructurales de esta versión.
 
-### 7. Escalada del incendio
+## Selección de rama
 
-- El ataque inicial no resuelve completamente el fuego.
-- El jugador debe asignar recursos limitados.
-- Las vulnerabilidades del invierno modifican dificultad y costes.
+El router evalúa el estado heredado y selecciona una de dos ramas:
 
-### 8. Cambio de viento y amenaza a viviendas
+- preparada, cuando existe margen operativo y oportunidad segura de ataque;
+- vulnerable, cuando una condición crítica de combustible, continuidad, acceso, defensibilidad o seguridad impide mantener el ataque.
 
-- Decisión entre evacuación, confinamiento, defensa del núcleo o redistribución de medios.
-- Accesos, defensibilidad y preparación ciudadana alteran las opciones disponibles.
+No existe una tercera rama intermedia. Los estados mixtos se resuelven mediante reglas explícitas de prioridad y seguridad.
 
-### 9. Crisis de comunicación
+## Resultado final
 
-- Saturación del 112.
-- Desinformación o imagen antigua viral.
-- Solo pueden ejecutarse dos actuaciones por escena.
+Existe un único nodo terminal:
 
-### 10. Noche y agotamiento operativo
+```text
+ending-result-causal-report
+```
 
-- Retirada de medios aéreos.
-- Relevo de cuadrillas o mantenimiento del ataque.
-- La preparación previa determina cuánto margen operativo queda.
+El nodo admite dos variantes:
 
-## Informe final causal
+- `contained`;
+- `overwhelmed`.
 
-El resultado debe explicar:
+La variante se calcula al finalizar desde `GameSession`, `inheritedState`, las decisiones de crisis y el historial causal. **No queda fijada únicamente por la rama seleccionada por el router.**
 
-- Qué medida preventiva redujo daños.
-- Qué carencia agravó la emergencia.
-- Qué decisiones de verano compensaron errores previos.
-- Qué daños podrían haberse evitado.
-- Población protegida.
-- Viviendas afectadas.
-- Confusión pública.
-- Seguridad de los equipos.
-- Resultado alternativo con una prevención diferente.
+Las dos partidas de referencia esperan:
 
-## Desenlaces
+- partida preparada → `contained`;
+- partida vulnerable → `overwhelmed`.
 
-- **Respuesta favorable:** la prevención proporciona margen operativo.
-- **Contención con daños:** la preparación parcial obliga a corregir durante la emergencia.
-- **Emergencia desbordada:** las vulnerabilidades acumuladas y la respuesta insuficiente superan la capacidad del operativo.
+Estos son resultados de aceptación reproducibles, no constantes codificadas en la transición. Los daños parciales y las correcciones realizadas durante la crisis se expresan dentro del informe causal; no crean un tercer nodo ni una tercera variante terminal.
 
-## Criterio de éxito de la beta
+## Informe causal
 
-Dos partidas con decisiones preventivas diferentes deben producir condiciones, opciones y resultados claramente distintos durante el verano.
+El resultado debe explicar entre tres y cinco relaciones prioritarias:
+
+1. actuación preventiva tomada u omitida;
+2. cambio en el estado heredado;
+3. momento de la crisis donde se manifestó;
+4. efecto sobre el fuego o la capacidad de ataque;
+5. alternativa preventiva relevante.
+
+Las consecuencias sociales pueden mostrarse después de explicar combustible, continuidad, accesos, defensibilidad y oportunidad de ataque.
+
+## Criterio de éxito
+
+Dos partidas con el mismo escenario externo y decisiones preventivas distintas deben producir:
+
+- estados heredados distintos;
+- ramas, opciones o dificultades visibles distintas;
+- comportamiento diferente del barranco compartido;
+- explicaciones causales distintas;
+- resultados reproducibles `contained` y `overwhelmed` en los fixtures de referencia.
 
 ## Base técnica acordada
 
-- Aplicación Fastify modular.
-- Motor TypeScript separado de la vista.
-- Reglas narrativas y heurísticas explicables.
-- Territorio ilustrado/SVG.
-- Contenido externo y editable.
-- Informe final generado desde el estado real de la partida.
+- aplicación Fastify modular;
+- motor TypeScript separado de la vista;
+- `GameSession` serializable y trazable;
+- flujo declarativo basado en IDs;
+- reglas puras e independientes del DOM;
+- contenido traducible con cobertura estricta para los 12 nodos;
+- validación automática del catálogo y de las dos partidas.
 
 ## Fuera de alcance
 
-- MapLibre y PostGIS.
-- Mapas geográficos reales.
-- Simulación física o celular avanzada.
-- Cuentas de usuario.
-- Multijugador.
-- Todos los escenarios existentes.
-- Frontend y backend separados.
+- una tercera inspección preventiva ejecutable;
+- una ruta obligatoria de comunicación o evacuación;
+- tres estados o tres desenlaces globales;
+- compatibilidad runtime con IDs históricos;
+- todos los escenarios existentes;
+- mapas geográficos reales;
+- simulación física avanzada;
+- cuentas de usuario y multijugador;
+- separación frontend/backend en esta fase.

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -1,316 +1,302 @@
 # Inventario actual del proyecto
 
-Fecha de revisión: 26 de julio de 2026  
-Repositorio revisado: `rakadie/juegoincendio`  
-Rama base: `main`
+Fecha de revisión inicial: 26 de julio de 2026  
+Última consolidación: 29 de julio de 2026  
+Repositorio: `rakadie/juegoincendio`  
+Rama de referencia: `main`
+
+## Propósito
+
+Este inventario distingue dos realidades que no deben confundirse:
+
+1. **Especificación aprobada de M1:** catálogo, IDs, flujo y modelo causal que deben implementarse.
+2. **Runtime heredado:** prototipo actual, todavía incompatible con parte de esa especificación.
+
+La fuente normativa para la Vertical Beta 1 es [`docs/product/vertical-beta-1-catalog.md`](../product/vertical-beta-1-catalog.md). La implementación se organiza en #67–#76, milestone **M2 — Motor modular**.
+
+Además, este documento conserva el inventario transversal del proyecto —interfaz, accesibilidad, territorio, assets, licencias, backend, calidad, despliegue y gobernanza—. Esas secciones registran capacidades y gaps, pero no modifican las decisiones normativas de producto.
 
 ## Criterios de clasificación
 
-- **Existe y es aprovechable**: implementado o suficientemente definido para reutilizarse.
-- **Existe, pero necesita revisión**: hay una base útil, aunque presenta deuda, inconsistencias o falta de validación.
-- **Es solo documentación o propuesta**: está descrito, pero no materializado en el producto.
-- **Falta implementar**: no se ha localizado una implementación funcional en la rama revisada.
-- **Fuera del alcance de la beta**: decisión explícita de no incluirlo en la Vertical Beta 1.
+- **Aprobado en especificación:** decisión cerrada y estable de M1.
+- **Existe y es reutilizable:** implementación actual aprovechable.
+- **Existe, pero debe migrarse:** base funcional incompatible con el contrato aprobado.
+- **Existe, pero necesita revisión:** capacidad útil con deuda o validación pendiente.
+- **Biblioteca candidata:** contenido conservado fuera del flujo oficial.
+- **Archivo histórico:** contenido retirado del producto y del runtime objetivo.
+- **Falta implementar:** contrato aprobado o necesidad identificada sin implementación funcional.
+- **Fuera del alcance de la beta:** decisión explícita de no incluirlo en la Vertical Beta 1.
 
 ## Resumen ejecutivo
 
-El repositorio contiene tres capas de avance distintas:
+El repositorio contiene:
 
-1. **Documentación extensa de producto y arquitectura**, con visión, dominio, frontend, backend, datos, testing, DevOps y gobierno del proyecto.
-2. **Contenido editorial estructurado**, con alrededor de cincuenta escenarios, variables, impactos, decisiones, textos revisables e internacionalización inicial.
-3. **Un prototipo vertical funcional**, servido por Fastify y construido principalmente dentro de una página HTML/JavaScript, con prevención, primer aviso, crisis, decisiones, variables, resultados y reinicio.
+- documentación extensa de producto, arquitectura, dominio, frontend, backend, testing y gobierno;
+- 51 objetos `Scenario` estructurados;
+- tres inspecciones preventivas heredadas;
+- balance, primer aviso y selector de rutas;
+- un prototipo Fastify funcional con gran parte del estado y las reglas embebidos en `prototype-page.ts`;
+- una especificación M1 cerrada para una Vertical Beta 1 de 12 nodos;
+- una épica M2 con nueve tareas de implementación.
 
-El producto ya supera el estado de maqueta estática. La dirección acordada es consolidar la aplicación Fastify existente mediante una arquitectura modular, sin migrar en esta fase a Next.js ni separar frontend y backend.
+El prototipo demuestra el concepto, pero **no es todavía la Vertical Beta 1 aprobada**. Conserva el catálogo completo, tres inspecciones, rutas antiguas, nodos invierno/verano, IDs históricos y resultado hardcodeado.
 
-La **Vertical Beta 1** queda definida como una partida ciudadana completa en dos momentos conectados:
+## 1. Producto aprobado
 
-- **Invierno:** prevención en viviendas, territorio y comunidad.
-- **Verano:** actuación ante un incendio condicionada por lo realizado —o no realizado— durante el invierno.
-
-El aprendizaje central es comprobar que la prevención cambia el margen operativo, los daños, la exposición de la población y la dificultad de las decisiones posteriores.
-
-La gobernanza editorial queda dividida en tres responsabilidades: los escenarios TypeScript mandan sobre estructura y reglas; el catálogo i18n español manda sobre los textos publicados; y los documentos Markdown sirven para revisión y aprobación, pero no alimentan directamente el juego.
-
-El dominio técnico oficial será ligero y estará centrado en una **`GameSession` o Partida**. Las reglas se extraerán de la interfaz a funciones TypeScript puras; los tipos de escena se unificarán progresivamente; `campaign.ts` declarará el flujo sin duplicar contenido; y el dominio de incendios activos con coordenadas se retirará por no formar parte de la experiencia narrativa de la beta.
-
----
-
-## 1. Producto y alcance
-
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Fuente normativa | Observación |
 |---|---|---|---|
-| Concepto de serious game sobre incendios | Existe y es aprovechable | `README.md`, documentación y prototipo | La propuesta de valor está formulada. |
-| Marca | Existe y es aprovechable | Decisión de producto | La marca oficial es **`¡Apaga las llamas!`**. Las referencias a `Guardián del Bosque` deben migrarse o archivarse. |
-| Público principal | Existe y es aprovechable | Decisión de producto | La beta se dirige a ciudadanía. Gestores y estudiantes quedan como públicos secundarios. |
-| Objetivo educativo | Existe y es aprovechable | Decisión de producto | Mostrar que la prevención de invierno modifica las condiciones y consecuencias de la emergencia de verano. |
-| Estructura temporal | Existe y es aprovechable | `campaign.ts`, inspecciones y escenarios | Invierno y verano no son modos separados, sino dos momentos causales de una misma partida. |
-| Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Recorrido oficial cerrado para la siguiente fase. |
-| Duración objetivo | Existe, pero necesita validación | Definición de la beta | Referencia inicial: 20–25 minutos. Debe comprobarse con usuarios. |
-| KPIs | Es solo documentación o propuesta | Documentación de producto | Falta convertirlos en métricas concretas de validación. |
-| Modelo de publicación y explotación | Falta implementar | Issue #9 | Debe definirse el formato inicial y el proveedor de despliegue. |
+| Marca `¡Apaga las llamas!` | Aprobado | Decisión de producto | Las referencias a marcas anteriores deben archivarse. |
+| Público principal: ciudadanía | Aprobado | #59, #66 | Gestores y estudiantes quedan como públicos secundarios. |
+| Eje causal territorial | Aprobado | #50, #66 | Prevención → fuego → capacidad de extinción → consecuencias. |
+| Duración 20–25 minutos | Aprobado y validado | #65 | Referencias aproximadas de 20 y 21 minutos. |
+| Catálogo de 12 nodos | Aprobado | #23 | Incluye seis tipos de nodo y un único terminal. |
+| Dos inspecciones | Aprobado | #54, #59 | Territorio 3/5; vivienda 2/3. |
+| Dos ramas | Aprobado | #61–#64 | Preparada y vulnerable. |
+| Resultado con dos variantes | Aprobado | #64, #66 | `contained` y `overwhelmed`, calculadas desde la sesión final. |
+| Avatar | Opcional | #56 | Fuera del flujo y de los fixtures. |
+| Comunicación y evacuación | Secundarias | #50, #66 | Consecuencias o contenido complementario, no eje estructural. |
+| Modelo de publicación | Pendiente | #9 | Bloquea despliegue y publicación, no el diseño del motor. |
+| Validación experta y ciudadana | Pendiente | #10 | Bloquea aprobación editorial y publicación, no los contratos técnicos. |
 
-### Recorrido oficial de la Vertical Beta 1
+## 2. Recorrido oficial
 
-#### Introducción
-
-1. Presentación del municipio, rol y objetivo.
-2. Elección de avatar.
-
-#### Fase 1 — Invierno: prevención
-
-3. **Viviendas y edificios:** inspección mediante hotspots y selección limitada de actuaciones.
-4. **Fincas, vegetación y combustible:** limpieza, accesos, quemas, pastoreo y continuidad vegetal.
-5. **Comunidad preparada:** familias, población vulnerable, canales oficiales, visitantes y puntos de apoyo.
-6. **Balance preventivo:** municipio preparado, preparación desigual o territorio vulnerable.
-
-#### Transición invierno–verano
-
-7. Declaración del incendio y presentación del estado heredado:
-   - defensibilidad de viviendas;
-   - continuidad del combustible;
-   - accesibilidad;
-   - preparación familiar;
-   - población vulnerable identificada;
-   - confianza ciudadana;
-   - claridad de canales oficiales;
-   - recursos disponibles.
-
-#### Fase 2 — Verano: actuación
-
-8. **Primer aviso:** verificación, movilización inicial y comunicación prudente.
-9. **Escalada del incendio:** asignación limitada de medios.
-10. **Cambio de viento:** amenaza a viviendas, evacuación y defensa operativa.
-11. **Crisis de comunicación:** saturación del 112 y desinformación visual.
-12. **Noche y agotamiento:** retirada de medios aéreos, defensa nocturna y relevo de equipos.
-13. **Informe final causal:** relación entre prevención, actuación y consecuencias.
-
-#### Desenlaces
-
-- Respuesta favorable: la prevención proporciona margen operativo.
-- Contención con daños: preparación parcial y decisiones correctivas.
-- Emergencia desbordada: vulnerabilidades acumuladas y respuesta insuficiente.
-
-#### Criterio de éxito del producto
-
-Dos partidas con decisiones preventivas diferentes deben producir condiciones, dificultades y resultados claramente distintos durante el verano.
-
----
-
-## 2. Escenarios y narrativa
-
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
-|---|---|---|---|
-| Catálogo de escenarios | Existe y es aprovechable | `src/content/scenarios/index.ts` | Hay aproximadamente 50 escenarios agrupados por prevención, comunicación y operaciones. |
-| Tipado común | Existe y es aprovechable | `src/domain/types/scenario.ts` | Incluye opciones, impactos, requisitos, desbloqueos, acciones, combinaciones y resultados. |
-| Pantallas preventivas | Existe y es aprovechable | `src/content/prevention-inspections.ts` | Son la base del invierno de la beta. |
-| Balance preventivo y primer aviso | Existe y es aprovechable | `src/content/prevention-balance.ts` | Es el puente central entre invierno y verano. |
-| Escenarios operativos de verano | Existe y es aprovechable | Escenarios `os-*` | Existe material suficiente para primer envío, escalado, viento, evacuación, noche y relevo. |
-| Ruta de comunicación | Existe y es aprovechable | `CRISIS_ROUTE_MODULE`, `cs-018`, `cs-023` | Aporta saturación del 112 y desinformación. |
-| Selección exacta de escenarios beta | Existe, pero necesita revisión | Vertical Beta 1 y catálogo | Debe fijarse el ID definitivo de cada escena y retirar duplicados. |
-| Modelo unificado de escenas | Es solo documentación o propuesta | `docs/architecture/decision-game-domain.md` | Crear una unión tipada para decisiones, inspecciones, resúmenes, rutas y selección de acciones. |
-| Grafo narrativo completo | Falta implementar | `nextLogic`, `routeLogic` parciales | Debe documentarse el flujo oficial y sus bifurcaciones. |
-| Coherencia de IDs y categorías | Existe, pero necesita revisión | Historial de renombrados | Hay que localizar duplicados, escenarios huérfanos y saltos de numeración. |
-| Validación experta | Falta implementar | Issue #10 | Debe definirse quién revisa el contenido operativo y cómo queda aprobado. |
-
-## 3. Motor de juego y dominio
-
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
-|---|---|---|---|
-| Estado de partida actual | Existe y es aprovechable | `buildInitialState()` | Registra fases, recursos, terreno, inspecciones, crisis y resultado. Debe migrarse al contrato `GameSession`. |
-| Dominio ligero centrado en `GameSession` | Es solo documentación o propuesta | `docs/architecture/decision-game-domain.md` | Es la arquitectura oficial para la beta y debe implementarse sin DDD/CQRS innecesarios. |
-| Aplicación de impactos | Existe y es aprovechable | `applyVector`, impactos de escenarios | Debe extraerse como regla TypeScript pura y testeable. |
-| Condiciones y transiciones | Existe y es aprovechable | `parseConditionExpression`, `scenarioNextStep` | Deben extraerse a un evaluador común de condiciones. |
-| Herencia invierno–verano | Existe, pero necesita revisión | Balance y métricas agregadas | Debe formalizarse como `inheritedState` dentro de la partida. |
-| Resultados dinámicos | Existe y es aprovechable | `finalizeCampaignResult()` | Debe migrarse a una regla de dominio que calcule el resultado desde el estado real. |
-| Informe causal | Existe, pero necesita revisión | Resultado y logs actuales | Debe explicar qué decisión preventiva causó o evitó cada consecuencia relevante. |
-| Flujo oficial de la beta | Es solo documentación o propuesta | `campaign.ts` y decisión de dominio | `campaign.ts` debe declarar orden y bifurcaciones sin repetir textos, opciones ni impactos. |
-| Persistencia de partida | Falta implementar | No localizada | Añadir `localStorage` sobre un estado serializable de `GameSession`. |
-| Motor separado de la interfaz | Falta implementar | Lógica embebida en `prototype-page.ts` | Extraer dominio, reglas y flujo a módulos TypeScript antes de rediseñar la interfaz. |
-| Dominio de incidentes de ejemplo | Existe, pero necesita revisión | `FireIncident`, repositorio y query handler | La decisión es retirarlo: no representa la partida ni el territorio narrativo de la beta. |
-| Motor narrativo y heurístico | Existe, pero necesita revisión | Variables, impactos y condiciones | Es la dirección oficial. Debe documentarse, implementarse como reglas puras y probarse. |
-| Simulación física o celular | Fuera del alcance de la beta | Documentación avanzada | No se implementará en Vertical Beta 1. |
-
-### Módulos de dominio acordados
+### Tronco común
 
 ```text
-src/game/
-├── domain/
-│   ├── game-session.ts
-│   ├── game-scene.ts
-│   ├── game-state.ts
-│   └── game-event.ts
-├── rules/
-│   ├── apply-decision.ts
-│   ├── evaluate-condition.ts
-│   ├── calculate-prevention.ts
-│   ├── transition-to-summer.ts
-│   └── calculate-result.ts
-└── flow/
-    └── vertical-beta-flow.ts
+intro-briefing-mission
+→ prevention-inspection-territory-fuel
+→ prevention-inspection-housing-interface
+→ transition-summary-prevention
+→ crisis-decision-first-alert
+→ crisis-router-causal-map
 ```
 
-Operaciones principales previstas:
+### Rama preparada
 
-- `createGameSession()`
-- `applyDecision()`
-- `completeInspection()`
-- `calculatePreventionBalance()`
-- `transitionToSummer()`
-- `resolveScenario()`
-- `calculateFinalResult()`
+```text
+crisis-decision-emergency-fuel-break
+→ crisis-decision-ravine-fire
+→ crisis-decision-housing-defense
+→ ending-result-causal-report
+```
 
-## 4. Interfaz y experiencia de usuario
+### Rama vulnerable
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+```text
+crisis-decision-access-blockage
+→ crisis-decision-ravine-fire
+→ crisis-decision-crown-fire
+→ ending-result-causal-report
+```
+
+El barranco es un nodo compartido. La variante terminal se calcula desde el estado final y las decisiones realizadas; las partidas de referencia esperan `contained` y `overwhelmed` respectivamente.
+
+## 3. Estado heredado aprobado
+
+`inheritedState` queda limitado a:
+
+- `fuelLoad`;
+- `fuelContinuity`;
+- `operationalAccess`;
+- `defensibility`;
+- `attackOpportunity`.
+
+No se incluyen preparación familiar, población vulnerable, confianza ciudadana o canales oficiales como dimensiones estructurales.
+
+## 4. Catálogo editorial
+
+### Objetos `Scenario`
+
+- `beta-oficial`: 5.
+- `biblioteca-candidata`: 36.
+- `archivo-historico`: 10.
+- Total: 51.
+
+### Unidades adicionales
+
+- `p-003-comunidad-preparada`: biblioteca candidata.
+- `invierno_1..3` y `verano_1..3`: archivo histórico.
+- `resultado-beta`: sentinela histórica que debe sustituirse por el nodo declarativo final.
+
+La clasificación completa y la correspondencia de IDs están en el catálogo canónico.
+
+## 5. Implementación existente
+
+| Componente | Estado actual | Tratamiento objetivo |
+|---|---|---|
+| `src/content/scenarios/index.ts` | Importa 51 escenarios | Exponer solo los cinco oficiales en el payload de la beta. |
+| `prevention-inspections.ts` | Tres inspecciones; p-001 y p-002 con siete opciones y cuota cuatro | Reducir a dos inspecciones, orden territorio→vivienda y cuotas 3/5 y 2/3. |
+| `prevention-balance.ts` | Mantiene dimensiones comunitarias y rutas antiguas | Reorientar a cinco dimensiones territoriales y dos ramas. |
+| `campaign.ts` | Conserva `invierno_*` y `verano_*` | Retirar el modelo paralelo del runtime oficial. |
+| `prototype-page.ts` | Estado, router, balance y resultado embebidos | Conectar la vista al motor y a `GameSession`. |
+| Selector de crisis | Fuerza `ruta-comunicacion` | Sustituir por router causal preparado/vulnerable. |
+| Cinco escenas oficiales | Formato no uniforme para el renderer | Adaptar al contrato común `GameScene`. |
+| Briefing y resultado | Hardcodeados | Convertir en nodos declarativos. |
+| i18n | IDs históricos y fallback silencioso | Cobertura estricta de los 12 nodos canónicos. |
+| Validación automática | No localizada para el catálogo | Validar IDs, referencias, ramas, terminal, i18n y fixtures. |
+
+## 6. Dominio y arquitectura objetivo
+
+| Elemento | Estado | Próximo destino |
+|---|---|---|
+| Unión discriminada `GameScene` | Falta implementar | #68 |
+| Validador de catálogo y grafo | Falta implementar | #68 |
+| `GameSession` serializable | Especificación M1 pendiente de completar | #28–#31 y #69 |
+| `inheritedState` territorial | Alcance aprobado; contrato detallado pendiente | #32–#35 y #69 |
+| Matriz causal | Alcance aprobado; detalle pendiente | #36–#39 |
+| Dos fixtures reproducibles | Secuencias aprobadas; fixtures pendientes | #44–#47 y #76 |
+| Motor separado del DOM | Falta implementar | #69, #72, #73 |
+| Flujo declarativo | Catálogo aprobado; runtime pendiente | #68 y #72 |
+| Retirada de campaña heredada | Aprobada | #74 |
+| Migración atómica de IDs e i18n | Aprobada | #75 |
+| Aceptación integral | Definida | #76 |
+| Simulación física o celular | Fuera de alcance | No implementar en Vertical Beta 1. |
+
+## 7. Interfaz y experiencia de usuario
+
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Prototipo navegable | Existe y es aprovechable | `/`, `/prototype` | Incluye recorrido y resultados. |
-| Playtest editorial | Existe y es aprovechable | `/game-content` | Útil para revisar escenarios de forma aislada. |
-| Responsive inicial | Existe y es aprovechable | Media queries | Requiere validación real en móvil y escritorio. |
-| Accesibilidad inicial | Existe, pero necesita revisión | Foco, diálogo, reducción de movimiento | Falta auditoría WCAG y pruebas completas con teclado. |
-| Distinción visual invierno–verano | Existe, pero necesita revisión | Etapas actuales | Debe reforzarse sin romper la continuidad causal. |
-| Componentización | Falta implementar | Dos archivos de interfaz muy grandes | Separar vistas, componentes, estado y eventos después de extraer el motor. |
-| Sistema de diseño | Es solo documentación o propuesta | Estilos embebidos y referencias visuales | Crear tokens y componentes reutilizables. |
+| Interfaz jugable del prototipo | Existe y es reutilizable | `prototype-page.ts` | Conservar la experiencia útil, pero retirar de la vista el cálculo de reglas y rutas. |
+| Inspecciones mediante hotspots | Existe, pero debe migrarse | Interfaz preventiva actual | Mantener solo las dos inspecciones oficiales y sus cuotas aprobadas. |
+| Flujo de briefing, prevención, crisis y resultado | Existe, pero debe migrarse | Pantallas y navegación actuales | Sustituir la navegación hardcodeada por el flujo declarativo. |
+| Responsive inicial | Existe, pero necesita revisión | Media queries y estilos actuales | Validar en móvil y escritorio con las pantallas definitivas. |
+| Accesibilidad inicial | Existe, pero necesita revisión | Foco, diálogos y reducción de movimiento | Realizar auditoría WCAG y pruebas completas con teclado. |
+| Distinción visual de fases | Existe, pero necesita revisión | Etapas actuales | Adaptar la terminología a prevención, transición, crisis y resultado. |
+| Componentización | Falta implementar | Archivos de interfaz grandes | Separar renderers y componentes después de extraer el motor; destino principal #73. |
+| Sistema de diseño | Es solo documentación o propuesta | Estilos embebidos | Definir tokens y componentes cuando el flujo esté estabilizado. |
 | Claridad informativa | Existe, pero necesita revisión | Textos largos y alta densidad | Jerarquizar contexto, decisión, consecuencias y ayuda. |
-| Sonido | Falta implementar en la versión actual | No localizado | Secundario frente al motor y al recorrido. |
+| Sonido | Falta implementar y no es prioritario | No localizado | Posponer frente al motor, accesibilidad y recorrido. |
 
-## 5. Mapa y territorio
+## 8. Territorio, mapas y datos
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| SVG de inspección | Existe y es aprovechable | Prototipo preventivo | Buena base para hotspots. |
-| Territorio ilustrado/SVG | Falta implementar | Decisión de producto | Solución oficial para la beta. |
-| Estados invierno–verano del territorio | Falta implementar | No localizado | El mismo territorio debe mostrar prevención y consecuencias posteriores. |
-| Capas narrativas | Falta implementar | No localizado | Zonas, carreteras, infraestructuras, población y recursos. |
-| Perímetro de incendio | Falta implementar | No localizado | Resolver con geometrías SVG predefinidas y estados. |
-| Movimiento de recursos | Falta implementar | No localizado | Resolver mediante posiciones y rutas narrativas SVG. |
-| Datos geográficos reales | Fuera del alcance de la beta | Sin PostGIS ni datasets | No son necesarios para validar el aprendizaje. |
-| MapLibre / Turf / PostGIS | Fuera del alcance de la beta | Documentación técnica | Reconsiderar solo en una fase posterior. |
+| Territorio ilustrado y zonas interactivas | Existe, pero necesita revisión | Interfaz y hotspots actuales | Mantener una representación narrativa, no una simulación GIS. |
+| Variables territoriales del juego | Existe, pero debe migrarse | Estado actual y balance | Reducirlas al contrato aprobado de `inheritedState`. |
+| Incendios activos con coordenadas | Existe como código de ejemplo | `FireIncident`, repositorio y `/fires/active` | Retirar del producto objetivo; no representa la partida narrativa. |
+| MapLibre y mapas reales | Fuera de alcance | Decisión de producto | No incorporar en Vertical Beta 1. |
+| PostgreSQL/PostGIS | Fuera de alcance | No implementado | No es necesario para una beta local o pública sin cuentas. |
+| Persistencia de sesión | Falta implementar | No localizada | Añadir persistencia local sobre `GameSession` serializable cuando el contrato esté estable. |
 
-## 6. Contenidos editoriales e internacionalización
+## 9. Assets, contenido e internacionalización
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Escenarios TypeScript | Existe y es aprovechable | `src/content/scenarios/` | Son la fuente de verdad de estructura, IDs, opciones, impactos, requisitos, flags, desbloqueos y transiciones. |
-| Catálogo i18n español | Existe y es aprovechable | `src/content/i18n/es/scenarios.ts` | Es la fuente de verdad de los textos publicados: títulos, contexto, preguntas, feedback y piezas narrativas. |
-| Documentos Markdown de revisión | Existe y es aprovechable | `docs/revision-textos/` | Son el espacio de revisión, comentarios y aprobación editorial; no constituyen una fuente ejecutable del juego. |
-| Script de extracción | Existe, pero necesita revisión | `scripts/extract-scenario-i18n.ts` | No debe sobrescribir el catálogo aprobado. Debe generar una base nueva, detectar campos ausentes o validar sincronización. |
-| Flujo editorial combinado | Existe y es aprovechable | Decisión de producto | TypeScript gobierna reglas; i18n gobierna textos; Markdown documenta revisión y aprobación. |
-| Sincronización y trazabilidad | Falta implementar | No hay automatización completa | Añadir validaciones para detectar IDs o campos desalineados y registrar qué revisión Markdown se ha incorporado al catálogo. |
-| Codificación UTF-8 | Existe, pero necesita revisión | Textos sin tildes o dañados | Requiere limpieza y pruebas automáticas. |
-| Segundo idioma | Fuera del alcance de la beta | Solo español | No es prioritario para Vertical Beta 1. |
+| Contenido editorial TypeScript | Existe y es reutilizable | `src/content/**` | Separar beta oficial, biblioteca y archivo sin borrar el material reutilizable. |
+| Catálogo i18n español | Existe, pero debe migrarse | Catálogo de traducciones actual | Migrar a IDs canónicos y eliminar fallback silencioso para los 12 nodos oficiales. |
+| Cobertura i18n oficial | Falta completar | #23 y #75 | Validar briefing, inspecciones, resumen, decisiones, router y resultado. |
+| Imágenes, iconos e ilustraciones | Existe, pero necesita inventario | Assets y estilos del prototipo | Mantener una lista de procedencia, uso y sustitución necesaria. |
+| Licencias de assets | Necesita revisión | No existe registro completo localizado | Documentar autoría y licencia antes de publicación pública. |
+| Audio | Falta implementar | No localizado | No bloquea el MVP. |
+| Biblioteca candidata | Existe | 36 escenarios y `p-003` | Conservar fuera del payload y sin obligación de migrar i18n en M2. |
 
-## 7. Recursos gráficos e iconografía
+## 10. Backend y API
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Imágenes principales | Existe y es aprovechable | `public/images/` | Funcionan como apoyo visual y referencia. |
-| Avatares | Existe y es aprovechable | Tres PNG | Ya están integrados. |
-| Iconografía funcional | Existe, pero necesita revisión | Emojis y símbolos | No constituye una familia final ni accesible. |
-| Sistema de iconos SVG | Falta implementar | No localizado | Debe coordinarse con el territorio ilustrado. |
-| Gestión de assets | Existe, pero necesita revisión | Rutas individuales Fastify | Servir `public` de forma estática y documentar origen. |
-| Licencias y atribución | Falta implementar | No localizado | Necesario antes de publicación. |
+| Servidor Fastify | Existe y es reutilizable | `server.ts`, `app.ts` | Base técnica oficial para una única aplicación. |
+| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript | Fastify servirá vistas y contenido; las reglas residirán en el motor. |
+| Healthcheck | Existe y es reutilizable | `/health` | Mantener y cubrir con prueba de integración. |
+| Endpoint de contenido | Existe, pero debe migrarse | `/game-content/data` | Entregar solo catálogo, flujo e inspecciones oficiales. |
+| Endpoint de incendios activos | Existe como ejemplo | `/fires/active` | Retirar junto con `FireIncident`. |
+| Autenticación y cuentas | Fuera de alcance | No implementado | No necesarias para la primera beta. |
+| Redis y bus de eventos | Fuera de alcance | Solo documentación | No necesarios para el motor narrativo. |
+| Persistencia de servidor | Fuera de alcance inicial | No implementada | Revaluar únicamente si #9 elige un formato que la necesite. |
 
-## 8. Backend, API y datos
+## 11. Testing, calidad y CI
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Servidor Fastify | Existe y es aprovechable | `server.ts`, `app.ts` | Base técnica oficial. |
-| Aplicación Fastify modular | Existe, pero necesita revisión | Estructura TypeScript y decisión de dominio | Fastify servirá vistas y contenido, pero no contendrá las reglas del juego. |
-| Healthcheck | Existe y es aprovechable | `/health` | Básico y funcional. |
-| Endpoint de contenido | Existe y es aprovechable | `/game-content/data` | Entrega variables, escenarios y campaña. Debe adaptarse al flujo y tipos unificados. |
-| Endpoint de incendios activos | Existe, pero necesita revisión | `/fires/active` | Se retirará junto con el dominio `FireIncident`, al ser código de ejemplo desconectado de la beta. |
-| Persistencia PostgreSQL/PostGIS | Fuera del alcance de la beta | No implementada | No necesaria para la primera beta. |
-| Redis y bus de eventos | Fuera del alcance de la beta | Solo documentación | No necesarios. |
-| Autenticación y cuentas | Fuera del alcance de la beta | No implementadas | No necesarias para una beta sin usuarios registrados. |
+| Vitest | Existe y es reutilizable | `package.json` | Base para pruebas unitarias y de integración. |
+| Tests unitarios del motor | Falta implementar o ampliar | No localizados para las reglas objetivo | Cubrir cada regla pura de `GameSession`, estado, router y resultado. |
+| Tests de integración HTTP | Falta implementar o ampliar | Cobertura no verificada | Cubrir healthcheck, payload oficial y errores de catálogo. |
+| Tests end-to-end | Falta implementar | Sin suite activa verificada | Cubrir las dos partidas de referencia. |
+| Typecheck y build | Existe | Scripts del repositorio | Mantener como puertas obligatorias de CI. |
+| CI | Existe parcialmente o debe reforzarse | Workflows del repositorio | Verificar que ejecute typecheck, build, tests y validación editorial. |
+| Validación del catálogo | Falta implementar | #68, #75 y #76 | Detectar duplicados, referencias inválidas, huérfanos, ciclos e i18n ausente. |
+| Validación experta y ciudadana | Pendiente | #10 | Definir revisores, muestra, guion, métricas, accesibilidad y aceptación educativa. |
+| Seguridad de dependencias y secretos | Necesita revisión continua | Configuración de repositorio y Actions | No exponer secretos en PR de forks y mantener dependencias revisadas. |
 
-## 9. Pruebas y calidad
+## 12. Despliegue y operación
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Vitest configurado | Existe y es aprovechable | `package.json` | Base para pruebas. |
-| Tests unitarios del motor | Falta implementar o no localizados | No localizados | Cubrir cada regla pura del nuevo dominio. |
-| Tests de integración HTTP | Falta implementar o no localizados | No localizados | Cubrir contenido, inicio y rutas principales. |
-| Tests end-to-end | Falta implementar | No Playwright activo | Cubrir al menos dos partidas preventivas diferentes. |
-| Typecheck y build | Existe y es aprovechable | Scripts disponibles | Deben ejecutarse en CI. |
-| CI | Falta implementar | Sin checks activos verificados | Añadir GitHub Actions para typecheck, build y tests. |
-| Validación del objetivo educativo | Falta implementar | Issue #10 | Comprobar que el usuario entiende la relación prevención–impacto. |
-| Validación editorial automatizada | Falta implementar | No localizada | Comprobar IDs, claves i18n, textos ausentes y divergencias antes de integrar cambios. |
+| Ejecución local | Existe y es reutilizable | Scripts npm | Base suficiente para desarrollo. |
+| Formato de publicación | Pendiente | #9 | Elegir demostrador, producto editorial, piloto o base licenciable. |
+| Proveedor de despliegue | Pendiente | #9 | Debe soportar una única aplicación Node.js/Fastify. |
+| Separación Railway + Vercel | Fuera de alcance | Decisión técnica | No separar frontend y backend en esta fase. |
+| Docker | No prioritario | No localizado como requisito | Incorporar solo si simplifica el proveedor elegido. |
+| Publicación automatizada | Falta implementar | CI/CD no validado para despliegue | Añadir después de elegir proveedor y estabilizar la beta. |
+| Variables y secretos | Necesita definición | #9 y configuración de Actions | Documentar variables, rotación y permisos mínimos. |
+| Registro de errores y uso | Pendiente | #9 | Definir el mínimo necesario para una beta pública. |
 
-## 10. Despliegue y operación
+## 13. Documentación, gobierno y pendientes
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
+| Elemento | Estado | Evidencia | Observación / siguiente acción |
 |---|---|---|---|
-| Ejecución local | Existe y es aprovechable | Scripts npm | Base suficiente para desarrollo. |
-| Despliegue de una app Fastify | Falta implementar | Issue #9 | Elegir un proveedor compatible con una única aplicación. |
-| Separación Railway + Vercel | Fuera del alcance de la beta | Documentación previa | No es necesaria al mantener una sola aplicación. |
-| Docker | No prioritario | No localizado | Evaluar solo si facilita el despliegue elegido. |
-| Publicación automatizada | Falta implementar | Sin CI/CD activo | Incorporar después de estabilizar la rama. |
+| Índice documental | Existe y es reutilizable | `docs/README.md` | Mantener navegación y señalar documentos normativos. |
+| Inventario actual | Existe y es reutilizable | Este documento | Mantener vivo sin sustituir inventarios transversales por decisiones de producto. |
+| Especificación Vertical Beta 1 | Vigente | `docs/product/vertical-beta-1.md` | Resume el producto aprobado. |
+| Catálogo canónico | Normativo | `docs/product/vertical-beta-1-catalog.md` | Fuente de verdad para nodos, IDs, flujo y clasificación. |
+| Decisión de dominio | Existe y es reutilizable | `docs/architecture/decision-game-domain.md` | Mantenerla alineada con `GameSession` y el motor ligero. |
+| Backlog documental previo | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Distinguir material vigente, absorbido e histórico. |
+| Material histórico | Existe | `docs/legacy`, `buzon` | No utilizar como fuente normativa sin validación. |
+| Issues como gestión | Existe | GitHub Issues y Projects | Mantener dependencias, milestones y estados coherentes. |
+| Criterios de terminado | Necesita consolidación | Issues M1/M2 | Cada entrega debe incluir pruebas, documentación y trazabilidad. |
+| Publicación y proveedor | Pendiente | #9 | No bloquear M1/M2 técnico, sí la salida pública. |
+| Validación experta y ciudadanía | Pendiente | #10 | No bloquear contratos técnicos, sí aprobación editorial y publicación. |
 
-## 11. Documentación y gestión
+## 14. Jerarquía de fuentes
 
-| Elemento | Clasificación | Evidencia | Observación / siguiente acción |
-|---|---|---|---|
-| Índice documental | Existe y es aprovechable | `docs/README.md` | Buena navegación. |
-| Inventario actual | Existe y es aprovechable | Este documento | Debe mantenerse vivo tras cada decisión de alcance. |
-| Especificación Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Define el producto inicial oficial. |
-| Decisión de dominio del juego | Existe y es aprovechable | `docs/architecture/decision-game-domain.md` | Define el dominio ligero centrado en partida y el plan de retirada del código de ejemplo. |
-| Backlog previo | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa. |
-| Material histórico | Existe, pero necesita revisión | `docs/legacy`, `buzon` | Separar vigente, referencia y archivo. |
-| Issues como gestión | Existe, pero necesita revisión | Issues #9 y #10 | Ya se registran decisiones diferidas; falta trasladar el roadmap técnico cuando se apruebe. |
-| Criterios de terminado | Es solo documentación o propuesta | Plantillas | Aplicarlos a los próximos hitos. |
+Cuando exista contradicción:
 
----
+1. decisiones cerradas de Product Owner (#59 y #66);
+2. catálogo canónico `vertical-beta-1-catalog.md`;
+3. especificaciones M1 de grafo, sesión, estado y causalidad;
+4. definición resumida `vertical-beta-1.md`;
+5. este inventario;
+6. documentación anterior y runtime heredado.
 
-## Decisiones de producto y arquitectura resueltas
+La existencia de una función o pantalla en el prototipo no la convierte en parte del producto aprobado. Del mismo modo, los gaps transversales de este inventario no alteran el catálogo causal.
 
-1. **Marca:** `¡Apaga las llamas!`.
-2. **Público principal:** ciudadanía.
-3. **Objetivo educativo:** mostrar el impacto de la prevención sobre la emergencia posterior.
-4. **Producto inicial:** Vertical Beta 1 en dos momentos conectados, invierno y verano.
-5. **Arquitectura:** mantener y modularizar Fastify.
-6. **Mapa:** territorio ilustrado/SVG.
-7. **Motor:** reglas narrativas y heurísticas explicables.
-8. **Fuente editorial:** TypeScript para estructura y reglas; catálogo i18n para textos publicados; Markdown para revisión y aprobación.
-9. **Dominio:** modelo ligero centrado en `GameSession`; reglas TypeScript puras; escenas unificadas; `campaign.ts` como flujo; retirada de `FireIncident` y `/fires/active`.
-10. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
+## 15. Próximo trabajo
 
-## Decisiones aún pendientes antes del roadmap
+M1 debe completar únicamente los contratos que desbloquean implementación:
 
-1. **Publicación — Issue #9:** formato de explotación y proveedor inicial.
-2. **Validación — Issue #10:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
+```text
+#24 → #25 → #26 → #27 → cerrar #14
+#28 → #29–#31
+#32 → #33–#35
+#36 → #37–#39
+#44 → #45–#47
+#40 → #41–#43
+```
 
-Estas decisiones están registradas como incidencias y no bloquean la especificación ni la implementación inicial del dominio del juego.
+M2 puede comenzar por etapas cuando estén cerradas sus entradas:
 
-## Vacíos prioritarios
+```text
+#23 + #24–#27 → #68
+#28–#35 → #69
+#68–#69 → #70 y #71
+→ #72 → #73 → #74 → #75 → #76
+```
 
-1. Fijar los IDs exactos de las escenas de la Vertical Beta 1.
-2. Documentar el grafo narrativo completo invierno–verano.
-3. Definir el contrato serializable de `GameSession` y del estado heredado entre fases.
-4. Crear los módulos `domain`, `rules` y `flow` acordados.
-5. Unificar progresivamente `Scenario`, `CampaignNode`, inspecciones, balances y rutas bajo tipos de escena comunes.
-6. Convertir `campaign.ts` en la declaración del flujo oficial sin contenido duplicado.
-7. Retirar `FireIncident`, su repositorio, query handler y `/fires/active`.
-8. Extraer de `prototype-page.ts` la aplicación de impactos, condiciones, transición estacional y cálculo de resultados.
-9. Crear pruebas que comparen partidas con prevención distinta.
-10. Adaptar el script y el flujo editorial para proteger el catálogo i18n aprobado.
-11. Añadir validaciones de sincronización entre escenarios, i18n y documentos de revisión.
-12. Diseñar el territorio ilustrado/SVG con estados estacionales.
-13. Añadir persistencia local.
-14. Crear un informe final causal completo.
-15. Configurar CI básico.
+Los pendientes transversales siguen su propio orden:
 
-## Recomendación de siguiente hito
+```text
+#9 → decisión de publicación y despliegue
+#10 → validación experta y pruebas con ciudadanía
+```
 
-El siguiente hito debe convertir la Vertical Beta 1 acordada en una **especificación funcional ejecutable y un dominio mínimo testeable**:
+## 16. Decisiones retiradas
 
-- escena por escena;
-- contrato de `GameSession`;
-- variables que hereda el verano;
-- condiciones y consecuencias;
-- tipos comunes de escena;
-- flujo oficial de la campaña;
-- contenido que se conserva;
-- contenido que queda fuera;
-- criterios de aceptación y pruebas.
+Quedan expresamente sustituidas y no deben utilizarse como entrada de M2:
 
-No debe iniciarse una migración de framework, un rediseño integral de interfaz ni una simulación geoespacial avanzada antes de completar y validar ese núcleo.
+- tercera inspección obligatoria de comunidad;
+- tres estados preventivos globales;
+- ruta principal de comunicación;
+- protagonismo estructural de evacuación;
+- tres desenlaces globales;
+- avatar obligatorio;
+- `inheritedState` comunitario;
+- compatibilidad runtime con IDs históricos.


### PR DESCRIPTION
## Objetivo

Resolver los comentarios de revisión de la PR #77 sin reabrir las decisiones de producto ya aprobadas ni reducir el inventario general del proyecto.

## Cambios

- actualiza `docs/product/vertical-beta-1.md` para retirar la antigua tercera inspección, los tres estados preventivos, la ruta central de comunicación y los tres desenlaces;
- aclara en `docs/product/vertical-beta-1-catalog.md` que las ramas determinan el recorrido, pero la variante `contained`/`overwhelmed` se calcula en el nodo final desde `GameSession`, `inheritedState`, decisiones de crisis e historial causal;
- mantiene las partidas preparada y vulnerable como fixtures con resultados esperados, no como constantes impuestas por el router;
- actualiza `docs/project/inventario-actual.md` para separar especificación aprobada y runtime heredado;
- preserva y actualiza el inventario transversal de interfaz/accesibilidad, territorio/mapas/datos, assets/licencias, backend/API, testing/CI, despliegue/operación y documentación/gobierno;
- conserva #9 y #10 como pendientes independientes de publicación y validación.

## Decisiones que no cambian

- solo dos inspecciones oficiales;
- `p-003-comunidad-preparada` permanece en biblioteca candidata;
- cinco dimensiones territoriales de `inheritedState`;
- dos ramas causales;
- un único nodo terminal con dos variantes;
- no se reintroduce un tercer desenlace.

## Integración

La rama está rebasada sobre el `main` actual: un commit por delante y cero por detrás. No sustituye ni elimina los cambios técnicos incorporados mientras se revisaba esta PR.

## Revisión que resuelve

- PR #77: “Reconcile the omitted community-preparation stage”.
- PR #77: “Preserve a decision-dependent partial ending”.
- PR #79: “Preserve the project-wide inventory sections”.

Relates to #9, #10, #23, #59, #66, #67