### PR TITLE
fix: comparar objetos JSON sin depender del orden

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "i18n:extract-scenarios": "tsx scripts/extract-scenario-i18n.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:contract": "vitest run tests/game-session-contract.test.ts",
+    "test:contract": "vitest run tests/game-session-contract.test.ts tests/game-session-transition-contract.test.ts tests/game-session-inherited-state-order.test.ts tests/game-session-key-order-contract.test.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/tests/game-session-key-order-contract.test.ts
+++ b/tests/game-session-key-order-contract.test.ts
@@ -22,6 +22,15 @@ function expectContractError(value: unknown, code: GameSessionContractErrorCode)
   expect(result.errors.map((error) => error.code)).toContain(code);
 }
 
+function defineEnumerableProtoKey(target: object, value: unknown): void {
+  Object.defineProperty(target, '__proto__', {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true
+  });
+}
+
 describe('GameSession structural JSON equality', () => {
   it('accepts equivalent InheritedState objects with different key order', async () => {
     const fixture = await loadCompletedFixture();
@@ -83,5 +92,21 @@ describe('GameSession structural JSON equality', () => {
     };
 
     expectContractError(fixture, 'session-completion-mismatch');
+  });
+
+  it('preserves an enumerable top-level __proto__ key so exact-key validation rejects it', async () => {
+    const fixture = await loadCompletedFixture();
+    defineEnumerableProtoKey(fixture, null);
+
+    expect(Object.prototype.hasOwnProperty.call(fixture, '__proto__')).toBe(true);
+    expectContractError(fixture, 'unexpected-key');
+  });
+
+  it('preserves an enumerable nested __proto__ key so structural validation rejects it', async () => {
+    const fixture = await loadCompletedFixture();
+    defineEnumerableProtoKey(fixture.inheritedState, 'unexpected');
+
+    expect(Object.prototype.hasOwnProperty.call(fixture.inheritedState, '__proto__')).toBe(true);
+    expectContractError(fixture, 'invalid-inherited-state');
   });
 });

--- a/tests/game-session-key-order-contract.test.ts
+++ b/tests/game-session-key-order-contract.test.ts
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  validateGameSessionContract,
+  type GameSessionContractErrorCode
+} from './support/game-session-contract.js';
+
+const FIXTURE_DIRECTORY = fileURLToPath(new URL('./fixtures/game-session/', import.meta.url));
+
+type MutableJson = Record<string, any>;
+
+async function loadCompletedFixture(): Promise<MutableJson> {
+  const text = await readFile(`${FIXTURE_DIRECTORY}completed-contained.json`, 'utf8');
+  return JSON.parse(text) as MutableJson;
+}
+
+function expectContractError(value: unknown, code: GameSessionContractErrorCode): void {
+  const result = validateGameSessionContract(value);
+  expect(result.valid).toBe(false);
+  if (result.valid) return;
+  expect(result.errors.map((error) => error.code)).toContain(code);
+}
+
+describe('GameSession structural JSON equality', () => {
+  it('accepts equivalent InheritedState objects with different key order', async () => {
+    const fixture = await loadCompletedFixture();
+    const inheritedEvent = fixture.history.find(
+      (event: MutableJson) => event.type === 'inherited-state-calculated'
+    );
+
+    inheritedEvent.state = {
+      attackOpportunity: fixture.inheritedState.attackOpportunity,
+      defensibility: fixture.inheritedState.defensibility,
+      operationalAccess: fixture.inheritedState.operationalAccess,
+      fuelContinuity: fixture.inheritedState.fuelContinuity,
+      fuelLoad: fixture.inheritedState.fuelLoad
+    };
+
+    expect(validateGameSessionContract(fixture)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('accepts equivalent result objects with different key order', async () => {
+    const fixture = await loadCompletedFixture();
+    const completedEvent = fixture.history.find(
+      (event: MutableJson) => event.type === 'session-completed'
+    );
+
+    completedEvent.result = {
+      evidenceIds: [...fixture.result.evidenceIds],
+      variant: fixture.result.variant
+    };
+
+    expect(validateGameSessionContract(fixture)).toEqual({ valid: true, errors: [] });
+  });
+
+  it('still rejects a reordered InheritedState when a value differs', async () => {
+    const fixture = await loadCompletedFixture();
+    const inheritedEvent = fixture.history.find(
+      (event: MutableJson) => event.type === 'inherited-state-calculated'
+    );
+
+    inheritedEvent.state = {
+      attackOpportunity: fixture.inheritedState.attackOpportunity,
+      defensibility: fixture.inheritedState.defensibility,
+      operationalAccess: fixture.inheritedState.operationalAccess,
+      fuelContinuity: fixture.inheritedState.fuelContinuity,
+      fuelLoad: fixture.inheritedState.fuelLoad + 1
+    };
+
+    expectContractError(fixture, 'corrupt-session-history');
+  });
+
+  it('keeps array order significant while ignoring object key order', async () => {
+    const fixture = await loadCompletedFixture();
+    const completedEvent = fixture.history.find(
+      (event: MutableJson) => event.type === 'session-completed'
+    );
+
+    completedEvent.result = {
+      evidenceIds: [...fixture.result.evidenceIds].reverse(),
+      variant: fixture.result.variant
+    };
+
+    expectContractError(fixture, 'session-completion-mismatch');
+  });
+});

--- a/tests/support/game-session-contract.ts
+++ b/tests/support/game-session-contract.ts
@@ -84,7 +84,10 @@ function canonicalizeJson(value: unknown, ancestors = new Set<object>()): unknow
       throw new TypeError('Only plain JSON objects can be canonicalized.');
     }
 
-    const canonical: Record<string, unknown> = {};
+    // A null-prototype target preserves every enumerable JSON key as an own
+    // data property. In particular, assigning "__proto__" cannot invoke the
+    // legacy Object.prototype setter and silently remove the unexpected key.
+    const canonical = Object.create(null) as Record<string, unknown>;
     for (const key of Object.keys(value).sort()) {
       canonical[key] = canonicalizeJson(value[key], ancestors);
     }

--- a/tests/support/game-session-contract.ts
+++ b/tests/support/game-session-contract.ts
@@ -60,11 +60,56 @@ function isPlainObject(value: unknown): value is JsonObject {
   return prototype === Object.prototype || prototype === null;
 }
 
+function canonicalizeJson(value: unknown, ancestors = new Set<object>()): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Non-finite numbers are not valid JSON.');
+    return value;
+  }
+
+  if (typeof value !== 'object') {
+    throw new TypeError('Only JSON-compatible values can be canonicalized.');
+  }
+
+  if (ancestors.has(value)) throw new TypeError('Circular values are not valid JSON.');
+  ancestors.add(value);
+
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => canonicalizeJson(item, ancestors));
+    }
+
+    if (!isPlainObject(value)) {
+      throw new TypeError('Only plain JSON objects can be canonicalized.');
+    }
+
+    const canonical: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      canonical[key] = canonicalizeJson(value[key], ancestors);
+    }
+    return canonical;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function canonicalizeContractInput(value: unknown): unknown {
+  try {
+    return canonicalizeJson(value);
+  } catch {
+    // Preserve malformed values so the base validator reports their original
+    // JSON/type error instead of normalizing the problem away.
+    return value;
+  }
+}
+
 function validateCanonicalTransitions(value: unknown): ContractValidationError[] {
-  if (!isPlainObject(value) || !Array.isArray(value.history)) return [];
+  if (!isPlainObject(value)) return [];
+  const history = value.history;
+  if (!Array.isArray(history)) return [];
 
   const errors: ContractValidationError[] = [];
-  const history = value.history;
   history.forEach((event, index) => {
     if (!isPlainObject(event) || event.type !== 'scene-transitioned') return;
     if (typeof event.fromSceneId !== 'string' || typeof event.toSceneId !== 'string') return;
@@ -83,10 +128,11 @@ function validateCanonicalTransitions(value: unknown): ContractValidationError[]
 }
 
 function validateInheritedStateCalculationOrder(value: unknown): ContractValidationError[] {
-  if (!isPlainObject(value) || !Array.isArray(value.history)) return [];
+  if (!isPlainObject(value)) return [];
+  const history = value.history;
+  if (!Array.isArray(history)) return [];
 
   const errors: ContractValidationError[] = [];
-  const history = value.history;
   const seenPreventionDecisionSequences: number[] = [];
 
   history.forEach((event, index) => {
@@ -148,10 +194,11 @@ function validateInheritedStateCalculationOrder(value: unknown): ContractValidat
 }
 
 export function validateGameSessionContract(value: unknown): ContractValidationResult {
-  const baseResult = validateBaseGameSessionContract(value);
+  const canonicalValue = canonicalizeContractInput(value);
+  const baseResult = validateBaseGameSessionContract(canonicalValue);
   const extensionErrors = [
-    ...validateCanonicalTransitions(value),
-    ...validateInheritedStateCalculationOrder(value)
+    ...validateCanonicalTransitions(canonicalValue),
+    ...validateInheritedStateCalculationOrder(canonicalValue)
   ];
 
   if (extensionErrors.length === 0) return baseResult;


### PR DESCRIPTION
## Resumen

Corrige el último hallazgo pendiente de la revisión de #31: la coherencia entre snapshot e historial ya no depende del orden de inserción de las claves de objetos JSON.

Refs #31 y el tercer comentario de revisión de la PR #80.

## Cambio

- canonicaliza recursivamente las claves de objetos JSON antes de ejecutar el validador base;
- conserva el orden de los arrays como parte de la semántica;
- no normaliza valores inválidos, clases, ciclos ni números no finitos, para que el validador base siga rechazándolos;
- mantiene las validaciones añadidas para aristas del grafo y orden del cálculo de `InheritedState`.

## Regresiones añadidas

- acepta `InheritedState` equivalente con las claves en orden inverso;
- acepta `result` equivalente con las claves en orden distinto;
- rechaza un estado reordenado cuando cambia un valor;
- rechaza un resultado cuando cambia el orden de `evidenceIds`, demostrando que los arrays siguen siendo posicionales.

## Puerta contractual

`npm run test:contract` ejecuta ahora explícitamente las cuatro suites contractuales:

- contrato base;
- aristas del grafo;
- orden de cálculo de `InheritedState`;
- igualdad estructural y orden de claves.

## Alcance

No modifica el contrato, el motor ni los fixtures. Corrige únicamente la comparación estructural del validador de tests.

## Validación

GitHub Actions `GameSession contract`: **success**.

- `npm run test:contract` ✅
- `npm test` ✅
- `npm run typecheck` ✅
- `npm run build` ✅

## Revisión

La issue #31 permanece abierta. Esta PR está preparada para revisión e integración antes de realizar la comprobación final de la issue.