### PR TITLE
test: validar integridad del grafo declarativo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - Tronco común y fases del grafo: [docs/product/vertical-beta-1-common-trunk.md](product/vertical-beta-1-common-trunk.md)
 - Ramas y convergencias de crisis: [docs/product/vertical-beta-1-crisis-branches.md](product/vertical-beta-1-crisis-branches.md)
 - Condiciones y transiciones del grafo: [docs/product/vertical-beta-1-graph-transitions.md](product/vertical-beta-1-graph-transitions.md)
+- Validación de integridad y formato declarativo: [docs/product/vertical-beta-1-graph-validation.md](product/vertical-beta-1-graph-validation.md)
 - Arquitectura de sistema: [docs/architecture/system-architecture.md](architecture/system-architecture.md)
 - Stack y decisiones técnicas: [docs/architecture/tech-stack-and-decisions.md](architecture/tech-stack-and-decisions.md)
 - Dominio y reglas del juego: [docs/domain/game-design-spec.md](domain/game-design-spec.md)

--- a/docs/product/vertical-beta-1-catalog.md
+++ b/docs/product/vertical-beta-1-catalog.md
@@ -117,6 +117,8 @@ Las dos ramas de crisis, el nodo compartido y su convergencia final se especific
 
 Los predicados deterministas, su prioridad, la conservación de rama y el tratamiento de estados inválidos se especifican en [`vertical-beta-1-graph-transitions.md`](vertical-beta-1-graph-transitions.md) como entrega de #26.
 
+La integridad, alcanzabilidad, ausencia de ciclos y estructura TypeScript de referencia se validan en [`vertical-beta-1-graph-validation.md`](vertical-beta-1-graph-validation.md) como entrega de #27.
+
 ## 5. Tabla definitiva
 
 | Posición | Fase | Rama | Unidad actual | ID canónico | Tipo | Fuente actual | Dependencias de entrada | Estado editorial | Destino en `campaign.ts` / flujo | Salidas canónicas |

--- a/docs/product/vertical-beta-1-common-trunk.md
+++ b/docs/product/vertical-beta-1-common-trunk.md
@@ -143,5 +143,5 @@ Estos artefactos son una especificación ejecutable de M1, no el motor del juego
 
 - #25 documenta las ramas preparada y vulnerable y su convergencia en [`vertical-beta-1-crisis-branches.md`](vertical-beta-1-crisis-branches.md);
 - #26 documenta las condiciones, prioridades y estados inválidos en [`vertical-beta-1-graph-transitions.md`](vertical-beta-1-graph-transitions.md);
-- #27 validará alcanzabilidad, ausencia de ciclos y formato declarativo del grafo completo;
+- #27 valida alcanzabilidad, ausencia de ciclos y formato declarativo en [`vertical-beta-1-graph-validation.md`](vertical-beta-1-graph-validation.md);
 - #68 implementará el contrato común `GameScene` y el validador del catálogo cuando M1 esté listo.

--- a/docs/product/vertical-beta-1-crisis-branches.md
+++ b/docs/product/vertical-beta-1-crisis-branches.md
@@ -176,6 +176,6 @@ Estos artefactos validan forma, recorrido e invariantes de M1. No implementan to
 ## 12. Entregas siguientes
 
 - #26 especifica predicados, prioridad, conservación de rama y errores de estado en [`vertical-beta-1-graph-transitions.md`](vertical-beta-1-graph-transitions.md);
-- #27 validará alcanzabilidad, convergencias, ausencia de ciclos y formato declarativo;
+- #27 valida alcanzabilidad, convergencias, ausencia de ciclos y formato declarativo en [`vertical-beta-1-graph-validation.md`](vertical-beta-1-graph-validation.md);
 - #35 aporta los efectos de `inheritedState` que condicionan la experiencia de crisis;
 - #68 implementará el contrato común y el validador del grafo cuando M1 esté listo.

--- a/docs/product/vertical-beta-1-graph-transitions.md
+++ b/docs/product/vertical-beta-1-graph-transitions.md
@@ -215,4 +215,4 @@ Los tests actuales demuestran forma, orden y aristas. Los umbrales, la validaci√
 
 ## 11. Entrega siguiente
 
-#27 podr√° validar el grafo completo como estructura declarativa: unicidad de IDs, alcanzabilidad desde el inicio, ausencia de ciclos, convergencias permitidas y correspondencia entre predicados y destinos.
+#27 valida el grafo completo en [`vertical-beta-1-graph-validation.md`](vertical-beta-1-graph-validation.md): unicidad de IDs, alcanzabilidad desde el inicio, ausencia de ciclos, convergencias permitidas y correspondencia entre predicados y destinos.

--- a/docs/product/vertical-beta-1-graph-validation.md
+++ b/docs/product/vertical-beta-1-graph-validation.md
@@ -1,0 +1,180 @@
+# Vertical Beta 1 — Validación de integridad y formato declarativo
+
+- Fecha: 16 de agosto de 2026
+- Issue: #27
+- Issue padre: #14
+- Entradas normativas: #23, #24, #25 y #26
+- Estado contrastado: `main@c2e94aea230be3735066de34ec57bbdfbf829e65`
+
+## 1. Propósito
+
+Este informe valida que el grafo aprobado de la Vertical Beta 1 es completo, alcanzable, acíclico y traducible al futuro `vertical-beta-flow.ts`. La entrega incluye un ejemplo TypeScript compilable y una prueba automática, ambos aislados del runtime hasta M2.
+
+## 2. Artefactos de validación
+
+| Artefacto | Función |
+|---|---|
+| `tests/support/vertical-beta-flow-example.ts` | Modelo declarativo mínimo, tipado y basado en referencias. |
+| `tests/vertical-beta-graph-integrity.test.ts` | Validación automática de nodos, aristas, alcance, ciclos, ramas y exclusiones. |
+| `docs/product/vertical-beta-1-graph-validation.md` | Método, resultados, límites y trazabilidad del estudio. |
+
+El ejemplo no contiene textos, impactos ni fórmulas. Cada nodo referencia contenido mediante `contentRef` y cada arista referencia un predicado aprobado en #26.
+
+## 3. Formato declarativo propuesto
+
+La unidad mínima es:
+
+```ts
+interface VerticalBetaFlowNode {
+  readonly id: CanonicalSceneId;
+  readonly type:
+    | 'briefing'
+    | 'inspection'
+    | 'summary'
+    | 'decision'
+    | 'router'
+    | 'result';
+  readonly contentRef: string;
+  readonly transitions: readonly {
+    readonly predicate: VerticalBetaTransitionPredicate;
+    readonly target: CanonicalSceneId;
+  }[];
+  readonly resultVariants?: readonly ResultVariant[];
+}
+```
+
+Ejemplo de convergencia sin duplicar el barranco:
+
+```ts
+{
+  id: 'crisis-decision-ravine-fire',
+  type: 'decision',
+  contentRef: 'scenario:s-027-fuego-en-barranco',
+  transitions: [
+    {
+      predicate: 'scene-completed:branch-prepared',
+      target: 'crisis-decision-housing-defense'
+    },
+    {
+      predicate: 'scene-completed:branch-vulnerable',
+      target: 'crisis-decision-crown-fire'
+    }
+  ]
+}
+```
+
+Los IDs de predicado son referencias. La lógica numérica y su prioridad permanecen definidas una sola vez en [`vertical-beta-1-graph-transitions.md`](vertical-beta-1-graph-transitions.md).
+
+## 4. Inventario validado
+
+| Propiedad | Valor validado |
+|---|---:|
+| Nodos canónicos únicos | 12 |
+| Tipos de nodo | 6 |
+| Aristas únicas | 13 |
+| Entradas | 1 |
+| Terminales | 1 |
+| Ramas condicionadas | 2 |
+| Nodos de barranco | 1 |
+| Variantes terminales | 2 |
+
+Los seis tipos presentes son `briefing`, `inspection`, `summary`, `decision`, `router` y `result`.
+
+## 5. Método de análisis
+
+La prueba ejecuta estas comprobaciones sobre la estructura de referencia:
+
+1. compara el orden y los 12 IDs con `CANONICAL_SCENE_IDS`;
+2. detecta IDs y referencias de contenido duplicados;
+3. comprueba que cada destino existe;
+4. calcula grados de entrada y salida;
+5. recorre el grafo desde `intro-briefing-mission`;
+6. ejecuta detección de ciclos mediante estados activo/finalizado;
+7. comprueba desde cada nodo que el terminal es alcanzable;
+8. resuelve las rutas preparada y vulnerable filtrando predicados por rama;
+9. verifica la instancia, predecesores y salidas del barranco;
+10. busca referencias expresamente excluidas en la representación serializada.
+
+## 6. Resultados
+
+| Riesgo comprobado | Resultado | Evidencia automática |
+|---|---|---|
+| IDs duplicados | No existen | 12 IDs, cardinalidad 12 |
+| Referencias inexistentes | No existen | Cada `target` pertenece al conjunto canónico |
+| Nodos huérfanos | No existen | Los 12 nodos son alcanzables desde la entrada |
+| Ciclos accidentales | No existen | Recorrido en profundidad sin retorno a nodo activo |
+| Rutas muertas | No existen | El terminal es alcanzable desde cada nodo |
+| Entradas múltiples | No existen | Solo `intro-briefing-mission` tiene grado de entrada 0 |
+| Terminales múltiples | No existen | Solo `ending-result-causal-report` carece de salidas |
+| Rama preparada inaccesible | No | Se resuelve una ruta condicionada completa |
+| Rama vulnerable inaccesible | No | Se resuelve una ruta condicionada completa |
+| Barranco duplicado | No | Existe una instancia con dos entradas y dos salidas condicionadas |
+| Resultados modelados como nodos | No | `contained` y `overwhelmed` solo aparecen en `resultVariants` |
+| Contenido excluido | No aparece | Escaneo de IDs y referencias en verde |
+
+## 7. Rutas condicionadas verificadas
+
+### Preparada
+
+```text
+crisis-router-causal-map
+→ crisis-decision-emergency-fuel-break
+→ crisis-decision-ravine-fire
+→ crisis-decision-housing-defense
+→ ending-result-causal-report [contained]
+```
+
+### Vulnerable
+
+```text
+crisis-router-causal-map
+→ crisis-decision-access-blockage
+→ crisis-decision-ravine-fire
+→ crisis-decision-crown-fire
+→ ending-result-causal-report [overwhelmed]
+```
+
+La evaluación por rama produce exactamente una transición aplicable en cada paso. Ambas rutas comparten el mismo nodo de barranco y convergen en el mismo resultado.
+
+## 8. Exclusiones verificadas
+
+La estructura no contiene referencias a:
+
+- comunicación o evacuación como rutas;
+- `p-003`;
+- `invierno_*`;
+- `verano_*`;
+- `resultado-beta`;
+- contenido de biblioteca o archivo.
+
+Los cinco escenarios ejecutables se incorporan únicamente mediante `contentRef`. El briefing, las dos inspecciones, el resumen, el primer aviso, el router y el resultado también se referencian por ID; no se copian sus textos o reglas.
+
+## 9. Frontera con M2
+
+Esta entrega valida la especificación de referencia, no la campaña heredada de `src/content/campaign.ts`. Esa campaña todavía contiene `invierno_*` y `verano_*` y será retirada por #74.
+
+M2 deberá:
+
+1. trasladar el tipo y los datos aprobados a `src/content/vertical-beta-flow.ts`;
+2. resolver `contentRef` contra el catálogo oficial;
+3. conectar los predicados con el evaluador de #72;
+4. ejecutar estas mismas invariantes contra el flujo real, no contra el ejemplo;
+5. eliminar el ejemplo de soporte cuando la implementación sea la fuente única.
+
+Esta frontera evita presentar una prueba de referencia como evidencia falsa de que el runtime ya fue migrado.
+
+## 10. Matriz de aceptación de #27
+
+| Criterio | Evidencia | Estado |
+|---|---|---|
+| Sin nodos huérfanos, ciclos o rutas muertas | Secciones 5–6 y test automático | Cumplido |
+| Ambas ramas alcanzables | Sección 7 y resolución condicionada | Cumplido |
+| Convergencia en un único resultado | Secciones 6–7 | Cumplido |
+| Variantes terminales, no nodos | Modelo `resultVariants` y test | Cumplido |
+| Una entrada y un terminal | Cálculo de grados | Cumplido |
+| Sin referencias excluidas | Sección 8 y escaneo automático | Cumplido |
+| Referencias por ID sin contenido duplicado | `contentRef` y predicados referenciados | Cumplido |
+
+## 11. Conclusión
+
+El grafo normativo de M1 supera las validaciones de integridad y dispone de un formato TypeScript mínimo y compilable. Puede servir como entrada directa de #72 y #76 sin arrastrar la campaña heredada ni duplicar contenido, impactos o reglas causales.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "i18n:extract-scenarios": "tsx scripts/extract-scenario-i18n.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:contract": "vitest run tests/game-session-contract.test.ts tests/game-session-transition-contract.test.ts tests/game-session-inherited-state-order.test.ts tests/game-session-key-order-contract.test.ts",
+    "test:contract": "vitest run tests/game-session-contract.test.ts tests/game-session-transition-contract.test.ts tests/game-session-inherited-state-order.test.ts tests/game-session-key-order-contract.test.ts tests/vertical-beta-graph-integrity.test.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/tests/support/vertical-beta-flow-example.ts
+++ b/tests/support/vertical-beta-flow-example.ts
@@ -1,0 +1,160 @@
+import {
+  CANONICAL_SCENE_IDS,
+  type CanonicalSceneId,
+  type CrisisBranch,
+  type ResultVariant
+} from './game-session-contract-base.js';
+
+export const VERTICAL_BETA_NODE_TYPES = [
+  'briefing',
+  'inspection',
+  'summary',
+  'decision',
+  'router',
+  'result'
+] as const;
+
+export type VerticalBetaNodeType = (typeof VERTICAL_BETA_NODE_TYPES)[number];
+
+export type VerticalBetaTransitionPredicate =
+  | 'scene-completed'
+  | 'scene-completed:router-prepared'
+  | 'scene-completed:router-vulnerable'
+  | 'scene-completed:branch-prepared'
+  | 'scene-completed:branch-vulnerable';
+
+export interface VerticalBetaTransition {
+  readonly predicate: VerticalBetaTransitionPredicate;
+  readonly target: CanonicalSceneId;
+}
+
+export interface VerticalBetaFlowNode {
+  readonly id: CanonicalSceneId;
+  readonly type: VerticalBetaNodeType;
+  readonly contentRef: string;
+  readonly transitions: readonly VerticalBetaTransition[];
+  readonly resultVariants?: readonly ResultVariant[];
+}
+
+export const VERTICAL_BETA_ENTRY_ID: CanonicalSceneId = 'intro-briefing-mission';
+export const VERTICAL_BETA_TERMINAL_ID: CanonicalSceneId = 'ending-result-causal-report';
+
+/**
+ * Reference-only declarative graph for M1. Runtime integration belongs to M2.
+ * Content and transition logic are referenced by ID instead of being copied here.
+ */
+export const VERTICAL_BETA_FLOW = [
+  {
+    id: 'intro-briefing-mission',
+    type: 'briefing',
+    contentRef: 'briefing:intro-briefing-mission',
+    transitions: [
+      { predicate: 'scene-completed', target: 'prevention-inspection-territory-fuel' }
+    ]
+  },
+  {
+    id: 'prevention-inspection-territory-fuel',
+    type: 'inspection',
+    contentRef: 'inspection:p-002-fincas-vegetacion-combustible',
+    transitions: [
+      { predicate: 'scene-completed', target: 'prevention-inspection-housing-interface' }
+    ]
+  },
+  {
+    id: 'prevention-inspection-housing-interface',
+    type: 'inspection',
+    contentRef: 'inspection:p-001-viviendas-interfaz',
+    transitions: [{ predicate: 'scene-completed', target: 'transition-summary-prevention' }]
+  },
+  {
+    id: 'transition-summary-prevention',
+    type: 'summary',
+    contentRef: 'summary:balance-prevencion',
+    transitions: [{ predicate: 'scene-completed', target: 'crisis-decision-first-alert' }]
+  },
+  {
+    id: 'crisis-decision-first-alert',
+    type: 'decision',
+    contentRef: 'scenario:s-040-primer-aviso-incendio',
+    transitions: [{ predicate: 'scene-completed', target: 'crisis-router-causal-map' }]
+  },
+  {
+    id: 'crisis-router-causal-map',
+    type: 'router',
+    contentRef: 'router:m-001-apertura-tres-frentes',
+    transitions: [
+      {
+        predicate: 'scene-completed:router-prepared',
+        target: 'crisis-decision-emergency-fuel-break'
+      },
+      {
+        predicate: 'scene-completed:router-vulnerable',
+        target: 'crisis-decision-access-blockage'
+      }
+    ]
+  },
+  {
+    id: 'crisis-decision-emergency-fuel-break',
+    type: 'decision',
+    contentRef: 'scenario:s-025-cortafuego-emergencia',
+    transitions: [
+      { predicate: 'scene-completed:branch-prepared', target: 'crisis-decision-ravine-fire' }
+    ]
+  },
+  {
+    id: 'crisis-decision-access-blockage',
+    type: 'decision',
+    contentRef: 'scenario:s-011-corte-carretera-acceso',
+    transitions: [
+      { predicate: 'scene-completed:branch-vulnerable', target: 'crisis-decision-ravine-fire' }
+    ]
+  },
+  {
+    id: 'crisis-decision-ravine-fire',
+    type: 'decision',
+    contentRef: 'scenario:s-027-fuego-en-barranco',
+    transitions: [
+      {
+        predicate: 'scene-completed:branch-prepared',
+        target: 'crisis-decision-housing-defense'
+      },
+      {
+        predicate: 'scene-completed:branch-vulnerable',
+        target: 'crisis-decision-crown-fire'
+      }
+    ]
+  },
+  {
+    id: 'crisis-decision-housing-defense',
+    type: 'decision',
+    contentRef: 'scenario:s-026-defensa-operativa-nucleo-viviendas',
+    transitions: [
+      { predicate: 'scene-completed:branch-prepared', target: 'ending-result-causal-report' }
+    ]
+  },
+  {
+    id: 'crisis-decision-crown-fire',
+    type: 'decision',
+    contentRef: 'scenario:s-030-fuego-de-copas',
+    transitions: [
+      { predicate: 'scene-completed:branch-vulnerable', target: 'ending-result-causal-report' }
+    ]
+  },
+  {
+    id: 'ending-result-causal-report',
+    type: 'result',
+    contentRef: 'result:ending-result-causal-report',
+    transitions: [],
+    resultVariants: ['contained', 'overwhelmed']
+  }
+] as const satisfies readonly VerticalBetaFlowNode[];
+
+// Compile-time alignment: changes to the canonical contract must be reflected here.
+export const VERTICAL_BETA_CANONICAL_IDS: readonly CanonicalSceneId[] = CANONICAL_SCENE_IDS;
+
+export function transitionAppliesToBranch(
+  predicate: VerticalBetaTransitionPredicate,
+  branch: CrisisBranch
+): boolean {
+  return predicate === 'scene-completed' || predicate.endsWith(branch);
+}

--- a/tests/vertical-beta-graph-integrity.test.ts
+++ b/tests/vertical-beta-graph-integrity.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import type { CanonicalSceneId, CrisisBranch } from './support/game-session-contract-base.js';
+import {
+  transitionAppliesToBranch,
+  VERTICAL_BETA_CANONICAL_IDS,
+  VERTICAL_BETA_ENTRY_ID,
+  VERTICAL_BETA_FLOW,
+  VERTICAL_BETA_NODE_TYPES,
+  VERTICAL_BETA_TERMINAL_ID,
+  type VerticalBetaTransition
+} from './support/vertical-beta-flow-example.js';
+
+const nodesById = new Map(VERTICAL_BETA_FLOW.map((node) => [node.id, node]));
+
+function outgoing(id: CanonicalSceneId): readonly VerticalBetaTransition[] {
+  return nodesById.get(id)?.transitions ?? [];
+}
+
+function reachableFrom(start: CanonicalSceneId): Set<CanonicalSceneId> {
+  const visited = new Set<CanonicalSceneId>();
+  const pending: CanonicalSceneId[] = [start];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === undefined || visited.has(current)) continue;
+    visited.add(current);
+    for (const transition of outgoing(current)) pending.push(transition.target);
+  }
+
+  return visited;
+}
+
+function hasCycle(): boolean {
+  const active = new Set<CanonicalSceneId>();
+  const finished = new Set<CanonicalSceneId>();
+
+  const visit = (id: CanonicalSceneId): boolean => {
+    if (active.has(id)) return true;
+    if (finished.has(id)) return false;
+
+    active.add(id);
+    for (const transition of outgoing(id)) {
+      if (visit(transition.target)) return true;
+    }
+    active.delete(id);
+    finished.add(id);
+    return false;
+  };
+
+  return VERTICAL_BETA_FLOW.some((node) => visit(node.id));
+}
+
+function pathForBranch(branch: CrisisBranch): CanonicalSceneId[] {
+  const path: CanonicalSceneId[] = ['crisis-router-causal-map'];
+  const visited = new Set(path);
+
+  while (path.at(-1) !== VERTICAL_BETA_TERMINAL_ID) {
+    const current = path.at(-1);
+    if (current === undefined) throw new Error('Branch path has no current node.');
+
+    const candidates = outgoing(current).filter((transition) =>
+      transitionAppliesToBranch(transition.predicate, branch)
+    );
+    if (candidates.length !== 1) {
+      throw new Error(`${current} has ${candidates.length} transitions for ${branch}.`);
+    }
+
+    const next = candidates[0].target;
+    if (visited.has(next)) throw new Error(`Cycle found while resolving ${branch}.`);
+    visited.add(next);
+    path.push(next);
+  }
+
+  return path;
+}
+
+describe('Vertical Beta 1 declarative graph integrity', () => {
+  it('contains the exact canonical nodes, types, references and variants', () => {
+    const ids = VERTICAL_BETA_FLOW.map((node) => node.id);
+    const types = new Set(VERTICAL_BETA_FLOW.map((node) => node.type));
+    const contentRefs = VERTICAL_BETA_FLOW.map((node) => node.contentRef);
+    const serialized = JSON.stringify(VERTICAL_BETA_FLOW);
+
+    expect(ids).toEqual(VERTICAL_BETA_CANONICAL_IDS);
+    expect(new Set(ids).size).toBe(12);
+    expect(types).toEqual(new Set(VERTICAL_BETA_NODE_TYPES));
+    expect(new Set(contentRefs).size).toBe(12);
+    expect(serialized).not.toMatch(/comunicaci[oó]n|evacuaci[oó]n|p-003|invierno_|verano_|resultado-beta/i);
+
+    const resultNodes = VERTICAL_BETA_FLOW.filter((node) => node.type === 'result');
+    expect(resultNodes).toHaveLength(1);
+    expect(resultNodes[0].id).toBe(VERTICAL_BETA_TERMINAL_ID);
+    expect(resultNodes[0].resultVariants).toEqual(['contained', 'overwhelmed']);
+    expect(ids).not.toContain('contained');
+    expect(ids).not.toContain('overwhelmed');
+  });
+
+  it('has valid references, one entry, one terminal and thirteen unique edges', () => {
+    const indegree = new Map(VERTICAL_BETA_FLOW.map((node) => [node.id, 0]));
+    const edgeKeys: string[] = [];
+
+    for (const node of VERTICAL_BETA_FLOW) {
+      for (const transition of node.transitions) {
+        expect(nodesById.has(transition.target)).toBe(true);
+        indegree.set(transition.target, (indegree.get(transition.target) ?? 0) + 1);
+        edgeKeys.push(`${node.id}->${transition.target}`);
+      }
+    }
+
+    const entries = VERTICAL_BETA_FLOW.filter((node) => indegree.get(node.id) === 0);
+    const terminals = VERTICAL_BETA_FLOW.filter((node) => node.transitions.length === 0);
+
+    expect(entries.map((node) => node.id)).toEqual([VERTICAL_BETA_ENTRY_ID]);
+    expect(terminals.map((node) => node.id)).toEqual([VERTICAL_BETA_TERMINAL_ID]);
+    expect(edgeKeys).toHaveLength(13);
+    expect(new Set(edgeKeys).size).toBe(13);
+  });
+
+  it('has no orphan nodes, dead routes or cycles', () => {
+    const reachable = reachableFrom(VERTICAL_BETA_ENTRY_ID);
+    expect(reachable).toEqual(new Set(VERTICAL_BETA_CANONICAL_IDS));
+    expect(hasCycle()).toBe(false);
+
+    for (const node of VERTICAL_BETA_FLOW) {
+      expect(reachableFrom(node.id).has(VERTICAL_BETA_TERMINAL_ID)).toBe(true);
+    }
+  });
+
+  it('keeps one shared ravine and resolves exactly one path per branch', () => {
+    const ravineNodes = VERTICAL_BETA_FLOW.filter(
+      (node) => node.id === 'crisis-decision-ravine-fire'
+    );
+    const ravinePredecessors = VERTICAL_BETA_FLOW.filter((node) =>
+      node.transitions.some((transition) => transition.target === 'crisis-decision-ravine-fire')
+    ).map((node) => node.id);
+
+    expect(ravineNodes).toHaveLength(1);
+    expect(ravinePredecessors).toEqual([
+      'crisis-decision-emergency-fuel-break',
+      'crisis-decision-access-blockage'
+    ]);
+
+    expect(pathForBranch('prepared')).toEqual([
+      'crisis-router-causal-map',
+      'crisis-decision-emergency-fuel-break',
+      'crisis-decision-ravine-fire',
+      'crisis-decision-housing-defense',
+      'ending-result-causal-report'
+    ]);
+    expect(pathForBranch('vulnerable')).toEqual([
+      'crisis-router-causal-map',
+      'crisis-decision-access-blockage',
+      'crisis-decision-ravine-fire',
+      'crisis-decision-crown-fire',
+      'ending-result-causal-report'
+    ]);
+  });
+});


### PR DESCRIPTION
## WHAT

- Añade un modelo TypeScript de referencia para los 12 nodos y 13 aristas de la Vertical Beta 1.
- Incorpora una prueba automática de unicidad, referencias, grados, alcanzabilidad, ciclos, rutas muertas, ramas y convergencia.
- Publica el informe de validación y enlaza la entrega desde la documentación normativa.
- Incluye la prueba de integridad en `test:contract`.

## FOR

Closes #27

La issue debe demostrar que el grafo aprobado es íntegro y trasladable al futuro `vertical-beta-flow.ts` antes de iniciar su implementación en M2.

## HOW

El modelo vive en soporte de tests y solo contiene IDs, tipos, `contentRef`, predicados referenciados y variantes. No modifica `src/`, no duplica textos, impactos o fórmulas y declara expresamente la frontera con la campaña heredada.

La prueba recorre el grafo, calcula grados, detecta ciclos, comprueba rutas al terminal y resuelve por separado las ramas `prepared` y `vulnerable`.

## Scope

- Issue: #27
- Tipo: `test/docs`
- Riesgo: `Low`
- Sin cambios de runtime, API o interfaz

## Validación

- [x] `npm.cmd run test:contract` — 35 pruebas
- [x] `npm.cmd test` — 38 pruebas
- [x] `npm.cmd run typecheck`
- [x] `npm.cmd run build`
- [x] `git diff --check`

## Resultado

- 12 IDs únicos y seis tipos.
- 13 aristas únicas con destinos existentes.
- Una entrada y un terminal.
- Cero nodos huérfanos, ciclos o rutas muertas.
- Dos rutas condicionadas alcanzables.
- Un único barranco compartido.
- `contained` y `overwhelmed` modelados como variantes.
- Sin referencias a contenido excluido.

## Riesgos y mitigación

| Riesgo | Impacto | Mitigación |
|---|---|---|
| Confundir referencia con runtime migrado | Cierre prematuro de M2 | El ejemplo queda aislado en tests y el informe explicita la frontera |
| Duplicar reglas causales | Divergencia con #26 | Las aristas usan IDs de predicado, sin copiar fórmulas |
| Validar solo la ruta preparada | Rama vulnerable rota | La prueba resuelve y compara ambas rutas completas |

## Rollback

Revertir el commit `d0aff6682a6a013c7746b07fea81de7ffb280894`.

## Checklist final

- [x] Informe de validación
- [x] Ejemplo TypeScript compilable
- [x] Prueba automática
- [x] Documentación enlazada
- [x] Sin cambios fuera de alcance