### PR TITLE
test: preparar fixtures canónicos de aceptación

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 - Escenario base común de las partidas de referencia: [docs/product/vertical-beta-1-reference-common.md](product/vertical-beta-1-reference-common.md)
 - Partida de referencia Municipio preparado: [docs/product/vertical-beta-1-reference-prepared.md](product/vertical-beta-1-reference-prepared.md)
 - Partida de referencia Territorio vulnerable: [docs/product/vertical-beta-1-reference-vulnerable.md](product/vertical-beta-1-reference-vulnerable.md)
+- Comparación y fixtures canónicos de las partidas de referencia: [docs/product/vertical-beta-1-reference-comparison.md](product/vertical-beta-1-reference-comparison.md)
 - Arquitectura de sistema: [docs/architecture/system-architecture.md](architecture/system-architecture.md)
 - Stack y decisiones técnicas: [docs/architecture/tech-stack-and-decisions.md](architecture/tech-stack-and-decisions.md)
 - Dominio y reglas del juego: [docs/domain/game-design-spec.md](domain/game-design-spec.md)

--- a/docs/domain/game-session-serialization.md
+++ b/docs/domain/game-session-serialization.md
@@ -6,7 +6,7 @@ Implementación de motor: fuera de alcance; corresponde a #69.
 
 ## Propósito
 
-Esta entrega convierte el contrato documental de `GameSession` en una especificación ejecutable mediante cuatro snapshots JSON, una matriz de cobertura y un validador puro utilizado únicamente por las pruebas.
+Esta entrega convierte el contrato documental de `GameSession` en una especificación ejecutable mediante snapshots JSON provisionales de contrato, dos partidas canónicas, un manifest de contexto, una matriz de cobertura y un validador puro utilizado únicamente por las pruebas.
 
 El objetivo no es simular todavía la partida. El objetivo es demostrar que cualquier implementación posterior puede:
 
@@ -24,13 +24,17 @@ tests/fixtures/game-session/
 ├── prevention-completed.json
 ├── crisis-prepared.json
 ├── completed-contained.json
+├── reference-context.json
+├── reference-contained.json
+├── reference-overwhelmed.json
 └── coverage.json
 
 tests/support/game-session-contract.ts
 tests/game-session-contract.test.ts
+tests/reference-game-sessions.test.ts
 ```
 
-Los valores causales incluidos son ejemplos válidos para comprobar forma y coherencia. No fijan los rangos, impactos o umbrales que deben definir #32–#35, ni sustituyen los fixtures canónicos de #44–#47.
+Los cuatro snapshots originales contienen valores causales provisionales válidos para comprobar forma y coherencia. No son parámetros normativos. `reference-contained.json` y `reference-overwhelmed.json` sí materializan los perfiles aprobados por #44–#47; `reference-context.json` mantiene sus invariantes externas fuera del contrato `GameSession`.
 
 ## Snapshots
 
@@ -50,7 +54,11 @@ Representa una sesión activa después de que el router haya seleccionado `prepa
 
 Representa una sesión cerrada sobre la rama preparada, con el nodo terminal completado y resultado `contained`.
 
-La prueba construye además en memoria una variante vulnerable completa y verifica que el mismo contrato admite `vulnerable` y `overwhelmed` sin añadir campos ni crear un segundo modelo de sesión.
+### Partidas canónicas de referencia
+
+`reference-contained.json` y `reference-overwhelmed.json` son dos sesiones completas, independientes y directamente consumibles por #76. Ambas conservan exactamente las mismas claves de `GameSession`; la segunda demuestra `vulnerable` y `overwhelmed` sin crear un segundo modelo.
+
+`reference-context.json` no es una sesión. Es el manifest determinista compartido que fija municipio, meteorología, ignición, reglas, límites y presupuesto de aceptación. Su separación evita añadir contexto externo, avatar o configuración al snapshot.
 
 ## Matriz de cobertura
 

--- a/docs/product/vertical-beta-1-reference-common.md
+++ b/docs/product/vertical-beta-1-reference-common.md
@@ -197,5 +197,5 @@ Comunicación, evacuación y daños solo pueden aparecer después como consecuen
 
 - #45 fija las cinco actuaciones y el guion preparado en [`vertical-beta-1-reference-prepared.md`](vertical-beta-1-reference-prepared.md);
 - #46 fija la partida vulnerable sin modificar ninguna variable común en [`vertical-beta-1-reference-vulnerable.md`](vertical-beta-1-reference-vulnerable.md);
-- #47 almacenará el manifest de contexto, construirá las dos sesiones JSON y comprobará igualdad y diferencias campo a campo;
+- #47 almacena el manifest, las dos sesiones y la comparación campo a campo en [`vertical-beta-1-reference-comparison.md`](vertical-beta-1-reference-comparison.md);
 - #43 evaluará esta entrega como `EV-10-REFERENCE-BASE` junto con `EV-11..EV-15`.

--- a/docs/product/vertical-beta-1-reference-comparison.md
+++ b/docs/product/vertical-beta-1-reference-comparison.md
@@ -1,0 +1,150 @@
+# Comparación y fixtures de las partidas de referencia
+
+Estado: especificación ejecutable de M1 para #47.
+
+Entradas: escenario común #44, partida preparada #45, partida vulnerable #46 y contrato `GameSession` #29–#31.
+
+Consumidor siguiente: aceptación integral del flujo en #76.
+
+## 1. Resultado
+
+Las dos partidas canónicas usan un único contexto externo versionado y el mismo contrato `GameSession`, pero conservan decisiones preventivas distintas. Los fixtures reproducen dos historiales deterministas de 32 eventos, 10 nodos y 9 decisiones:
+
+- `reference-contained.json`: rama `prepared`, resultado `contained`;
+- `reference-overwhelmed.json`: rama `vulnerable`, resultado `overwhelmed`.
+
+El contexto vive en `reference-context.json`; no se añade a `GameSession`. Esta separación mantiene sus nueve claves exactas y permite que el harness de #76 inyecte una sola referencia en ambas ejecuciones.
+
+## 2. Artefactos canónicos
+
+| Artefacto | Responsabilidad |
+|---|---|
+| `tests/fixtures/game-session/reference-context.json` | Contexto, reglas, ausencia de azar, límites y presupuesto de aceptación compartidos. |
+| `tests/fixtures/game-session/reference-contained.json` | Snapshot e historial completos de Municipio preparado. |
+| `tests/fixtures/game-session/reference-overwhelmed.json` | Snapshot e historial completos de Territorio vulnerable. |
+| `tests/reference-game-sessions.test.ts` | Contrato, round-trip, contexto, IDs, recorridos, decisiones, dimensiones y resultados. |
+
+`initial.json`, `prevention-completed.json`, `crisis-prepared.json` y `completed-contained.json` continúan como snapshots provisionales de forma y corrupción. No son parámetros causales normativos y no deben sustituir los dos fixtures de referencia.
+
+## 3. Invariantes compartidas
+
+| Campo | Valor único para ambas partidas |
+|---|---|
+| Contexto | `vb1-reference-context-v1` |
+| Municipio | `fictional-ravine-interface-municipality-v1` |
+| Meteorología | `dry-windy-daylight-v1`; 13:42, luz diurna, sin precipitación, cálido, humedad baja y rachas irregulares del barranco a la interfaz |
+| Ignición | `lower-ravine-rural-track-v1`; borde de pista rural, causa sin confirmar |
+| Capacidad externa | `standard-response-capacity-v1` |
+| Exposición | `same-homes-and-positions-v1` |
+| Reglas | `m1-reference-rules-v1`, `GameSession.schemaVersion = 1` |
+| Azar | `none` |
+| Límites preventivos | 3 elecciones territoriales y 2 de vivienda |
+| Primer aviso | `movilizar-y-verificar` |
+| Barranco | `asegurar-flancos-y-repliegue` |
+| Presupuesto | 10 nodos, 9 decisiones, 22 minutos estimados; objetivo 20–25 |
+
+No se incluyen avatar, rasgos sociales, variación de capacidad, comunicación ni evacuación como causas primarias. Comunicación y evacuación solo pueden aparecer después como consecuencias derivadas del estado y de las decisiones.
+
+## 4. Comparación campo a campo
+
+| Aspecto | Municipio preparado | Territorio vulnerable | Diferencia atribuible |
+|---|---|---|---|
+| Prevención territorial | restos, discontinuidades y márgenes | restos, pastoreo y evaluación técnica | Tres selecciones distintas; la segunda conserva continuidad territorial y obstáculos de acceso. |
+| Prevención de vivienda | poda y accesos | poda y separación de copas | Una selección distinta; la segunda mejora copas, pero no el acceso local. |
+| `fuelLoad` | `45`, moderada | `25`, moderada | Pastoreo reduce más la carga vulnerable; esa mejora se conserva en el informe. |
+| `fuelContinuity` | `25`, discontinua | `35`, discontinua | Discontinuidad territorial frente a separación de copas. |
+| `operationalAccess` | `80`, robusto | `20`, bloqueado | Márgenes y acceso local realizados frente a ambos omitidos. |
+| `defensibility` | `50`, viable | `30`, débil; utilizable `20` | La mejora local vulnerable queda limitada por acceso. |
+| `attackOpportunity` | `66`, viable | `24`, inexistente | La línea evaluada vulnerable no es operable sin cadena de acceso. |
+| Combinaciones activas | C-01, C-04, C-05 | C-01, C-03 | Cambian tres de cinco combinaciones. |
+| Rama | `prepared` | `vulnerable` | Vetos de acceso y oportunidad fuerzan la segunda. |
+| Apertura de crisis | maniobra condicionada | corredor temporal limitado | Capacidad preventiva disponible frente a recuperación reactiva incompleta. |
+| Barranco | posición sostenida con repliegue | posición no sostenible; repliegue | Mismo nodo y acción, efecto distinto por estado heredado. |
+| Última escena de decisión | defensa selectiva de viviendas | repliegue ante fuego de copas | La capacidad preparada se mantiene; la vulnerable queda superada. |
+| Resultado | `contained` | `overwhelmed` | Informes opuestos sin cambiar el contexto externo. |
+
+Las cinco dimensiones difieren, por encima del mínimo de tres exigido por #47. Que `fuelLoad` sea menor en la partida vulnerable no contradice el resultado: muestra que una mejora aislada no reemplaza la cadena de acceso, la defensibilidad ni una oportunidad de ataque utilizable.
+
+## 5. Opciones disponibles y bloqueadas
+
+Los fixtures guardan solo decisiones seleccionadas. Las expectativas derivadas que deberá comprobar el motor de #76 son:
+
+| Escena | Preparada | Vulnerable |
+|---|---|---|
+| Router | disponible `emergency-fuel-break`; bloqueada `access-blockage` | disponible `access-blockage`; bloqueada `emergency-fuel-break` |
+| Apertura | seleccionada `autorizar-maniobra-condicionada`; bloqueada `usar-linea-profesional-no-evaluada` | seleccionada `despejar-corredor-operativo`; bloqueadas maquinaria sin repliegue y línea sin acceso |
+| Barranco | disponible `mantener-ataque-anclado`; bloqueado ataque directo sin anclaje | disponible vigilancia indirecta; bloqueados ataque anclado y directo sin anclaje |
+| Cierre de crisis | defensa selectiva disponible; defensa total sin repliegue bloqueada | ataque indirecto disponible; ataque directo y defensa sin salida bloqueados |
+| Resultado | disponible `contained`; bloqueado `overwhelmed` | disponible `overwhelmed`; bloqueado `contained` |
+
+Estas opciones no se serializan como estado paralelo. Se derivan del `inheritedState`, evidencias, rama y escena actual definidos por los fixtures.
+
+## 6. Recorridos e IDs exactos
+
+Tronco compartido:
+
+```text
+intro-briefing-mission
+prevention-inspection-territory-fuel
+prevention-inspection-housing-interface
+transition-summary-prevention
+crisis-decision-first-alert
+crisis-router-causal-map
+```
+
+Final preparado:
+
+```text
+crisis-decision-emergency-fuel-break
+crisis-decision-ravine-fire
+crisis-decision-housing-defense
+ending-result-causal-report
+```
+
+Final vulnerable:
+
+```text
+crisis-decision-access-blockage
+crisis-decision-ravine-fire
+crisis-decision-crown-fire
+ending-result-causal-report
+```
+
+Cada historial contiene secuencias de evento `1..32` y de decisión `1..9`, sin huecos. Briefing, resumen, router y resultado no crean decisiones. El cálculo de estado se registra inmediatamente después de cerrar la segunda inspección y referencia exactamente las decisiones `1..5`.
+
+## 7. Informe causal esperado
+
+El resultado preparado conserva cinco relaciones: amortiguación del comportamiento, accesos territorial y local, envolvente segura de ataque, posición sostenible en el barranco y defensa selectiva de viviendas.
+
+El resultado vulnerable conserva también las mejoras reales de carga y copas, y explica el desenlace mediante la cadena de acceso ausente, la posición no sostenible del barranco y el repliegue seguro ante fuego de copas. Una decisión segura de repliegue nunca se presenta como causa de `overwhelmed`.
+
+Los `evidenceIds` finales de cada fixture son distintos, aparecen tanto en `scene-completed` del resultado como en `session-completed`, y permiten reconstruir el informe sin puntuaciones visibles ni causalidad social.
+
+## 8. Uso directo por #76
+
+El test de aceptación integral debe:
+
+1. cargar una vez `reference-context.json`;
+2. ejecutar cada lista de `decisions` con azar desactivado;
+3. comparar el snapshot producido con el fixture correspondiente;
+4. exigir igualdad exacta de `completedSceneIds`, historia, rama, resultado y evidencias;
+5. comprobar las opciones derivadas de la sección 5 sin persistirlas dentro de `GameSession`;
+6. fallar ante alias, IDs desconocidos, dimensiones distintas de las aprobadas o cualquier dependencia del orden de ejecución.
+
+Los JSON no dependen de HTTP, DOM, Fastify, texto traducido ni reloj real. Por ello son deterministas y directamente consumibles desde pruebas de dominio o integración.
+
+## 9. Matriz de aceptación de #47
+
+| Criterio | Evidencia | Estado |
+|---|---|---|
+| Diferencias nacen de decisiones preventivas identificables | Secciones 3–4 y secuencias exactas en ambos JSON | Cumplido |
+| Al menos tres dimensiones cambian | Las cinco dimensiones cambian y el test las compara | Cumplido |
+| IDs exactos y recorrido completo | Sección 6, fixtures y validador de contrato | Cumplido |
+| Mismo barranco con efectos diferentes | Mismo `actionId`, dos evidencias explícitas y test dedicado | Cumplido |
+| Resultados `contained` / `overwhelmed` | Snapshots, eventos finales y prueba automática | Cumplido |
+| Contexto idéntico | Manifest único fuera de `GameSession` y prueba de forma exacta | Cumplido |
+| Fixtures deterministas para #76 | Sección 8, round-trip y ausencia de azar | Cumplido |
+
+## 10. Exclusiones
+
+Esta entrega no implementa el motor #69, el renderer, las opciones de interfaz ni la aceptación integral #76. Tampoco convierte valores de diseño en garantías científicas o de respuesta real; mantiene las puertas de validación experta de #10.

--- a/docs/product/vertical-beta-1-reference-prepared.md
+++ b/docs/product/vertical-beta-1-reference-prepared.md
@@ -294,5 +294,5 @@ Esta entrega no crea todavía el JSON canónico de #47, no modifica el fixture p
 ## 14. Entregas siguientes
 
 - #46 utiliza el mismo contexto y contrasta este guion en [`vertical-beta-1-reference-vulnerable.md`](vertical-beta-1-reference-vulnerable.md);
-- #47 materializará `reference-contained.json`, validará esta secuencia y comparará ambas sesiones;
+- #47 materializa `reference-contained.json`, valida esta secuencia y compara ambas sesiones en [`vertical-beta-1-reference-comparison.md`](vertical-beta-1-reference-comparison.md);
 - #43 evaluará esta entrega como `EV-11-REFERENCE-PREPARED`.

--- a/docs/product/vertical-beta-1-reference-vulnerable.md
+++ b/docs/product/vertical-beta-1-reference-vulnerable.md
@@ -326,5 +326,5 @@ Esta entrega no crea todavía el JSON canónico de #47, no altera el perfil apro
 
 ## 16. Entregas siguientes
 
-- #47 materializará `reference-overwhelmed.json` y comparará las dos sesiones y su contexto;
+- #47 materializa `reference-overwhelmed.json` y compara las dos sesiones y su contexto en [`vertical-beta-1-reference-comparison.md`](vertical-beta-1-reference-comparison.md);
 - #43 evaluará esta entrega como `EV-12-REFERENCE-VULNERABLE`.

--- a/docs/project/m1-acceptance-evidence.md
+++ b/docs/project/m1-acceptance-evidence.md
@@ -85,7 +85,7 @@ Reglas:
 | `EV-10-REFERENCE-BASE` | [`vertical-beta-1-reference-common.md`](../product/vertical-beta-1-reference-common.md): contexto versionado, supuestos, estado base, tronco, presupuesto temporal y variables inmutables compartidas. | Disponible. |
 | `EV-11-REFERENCE-PREPARED` | [`vertical-beta-1-reference-prepared.md`](../product/vertical-beta-1-reference-prepared.md): decisiones, evidencias, cálculo, opciones, consecuencias, duración, recorrido e informe `contained`. | Disponible. |
 | `EV-12-REFERENCE-VULNERABLE` | [`vertical-beta-1-reference-vulnerable.md`](../product/vertical-beta-1-reference-vulnerable.md): decisiones/omisiones, evidencias, cálculo, opciones, consecuencias, duración, recorrido e informe `overwhelmed`. | Disponible. |
-| `EV-13-REFERENCE-AUTO` | Entrega de #47: `tests/fixtures/game-session/reference-contained.json`, `reference-overwhelmed.json` y `tests/reference-game-sessions.test.ts`; ejecutar suite, round-trip y comparación de contexto/dimensiones/rutas. | Pendiente de #47. |
+| `EV-13-REFERENCE-AUTO` | [`vertical-beta-1-reference-comparison.md`](../product/vertical-beta-1-reference-comparison.md), `tests/fixtures/game-session/reference-context.json`, `reference-contained.json`, `reference-overwhelmed.json` y `tests/reference-game-sessions.test.ts`; ejecutar suite, round-trip y comparación de contexto/dimensiones/rutas. | Disponible. |
 | `EV-14-I18N-SPEC` | Sección i18n de [`vertical-beta-1-catalog.md`](../product/vertical-beta-1-catalog.md) y contrato de [`vertical-beta-1-causal-report.md`](../product/vertical-beta-1-causal-report.md). Inventariar 12 nodos y familias de claves, sin fallback como resultado válido. | Disponible; completar con #45–#46. |
 | `EV-15-CROSS-AUDIT` | Informe de #43 en `docs/project/m1-final-acceptance.md`: manifest de fuentes normativas, SHA único, conteos cruzados, hallazgos y estado de las 35 filas. | Pendiente de #43. |
 
@@ -173,7 +173,7 @@ La matriz contiene:
 - 35 severidades `m1-blocker` justificadas por el carácter obligatorio de #40;
 - 35 estados `not-evaluated`, porque #43 aún no se ha ejecutado.
 
-G1–G5 disponen de fuentes; G6 ya dispone de `EV-10..EV-12` y depende de #47 para `EV-13`; G7 necesita la auditoría cruzada final de #43. Esta diferencia de disponibilidad no cambia el estado de aceptación.
+G1–G6 disponen de `EV-01..EV-14`; G7 necesita la auditoría cruzada final de #43 para `EV-15`. Esta diferencia de disponibilidad no cambia el estado de aceptación.
 
 ## 8. Trabajo posterior y no bloqueante para M1
 
@@ -209,5 +209,5 @@ Esta entrega no:
 ## 11. Entregas siguientes
 
 - #42 compone la [`Definition of Ready de M2`](m2-definition-of-ready.md) a partir de los 35 `m1-blocker`, sus firmas y el tratamiento de reapertura;
-- #44–#47 producirán EV-10..13;
+- #44–#47 produjeron EV-10..13;
 - #43 congelará el SHA, producirá EV-15 y evaluará cada fila.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "i18n:extract-scenarios": "tsx scripts/extract-scenario-i18n.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:contract": "vitest run tests/game-session-contract.test.ts tests/game-session-transition-contract.test.ts tests/game-session-inherited-state-order.test.ts tests/game-session-key-order-contract.test.ts tests/vertical-beta-graph-integrity.test.ts",
+    "test:contract": "vitest run tests/game-session-contract.test.ts tests/game-session-transition-contract.test.ts tests/game-session-inherited-state-order.test.ts tests/game-session-key-order-contract.test.ts tests/vertical-beta-graph-integrity.test.ts tests/reference-game-sessions.test.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/tests/fixtures/game-session/reference-contained.json
+++ b/tests/fixtures/game-session/reference-contained.json
@@ -1,0 +1,148 @@
+{
+  "schemaVersion": 1,
+  "id": "reference-contained-v1",
+  "status": "completed",
+  "progress": {
+    "currentSceneId": "ending-result-causal-report",
+    "completedSceneIds": [
+      "intro-briefing-mission",
+      "prevention-inspection-territory-fuel",
+      "prevention-inspection-housing-interface",
+      "transition-summary-prevention",
+      "crisis-decision-first-alert",
+      "crisis-router-causal-map",
+      "crisis-decision-emergency-fuel-break",
+      "crisis-decision-ravine-fire",
+      "crisis-decision-housing-defense",
+      "ending-result-causal-report"
+    ]
+  },
+  "decisions": [
+    { "sequence": 1, "sceneId": "prevention-inspection-territory-fuel", "actionId": "gestionar-restos-poda" },
+    { "sequence": 2, "sceneId": "prevention-inspection-territory-fuel", "actionId": "crear-discontinuidades-vegetales" },
+    { "sequence": 3, "sceneId": "prevention-inspection-territory-fuel", "actionId": "limpiar-margenes-caminos" },
+    { "sequence": 4, "sceneId": "prevention-inspection-housing-interface", "actionId": "podar-ramas-y-retirar-seco" },
+    { "sequence": 5, "sceneId": "prevention-inspection-housing-interface", "actionId": "despejar-accesos" },
+    { "sequence": 6, "sceneId": "crisis-decision-first-alert", "actionId": "movilizar-y-verificar" },
+    { "sequence": 7, "sceneId": "crisis-decision-emergency-fuel-break", "actionId": "autorizar-maniobra-condicionada" },
+    { "sequence": 8, "sceneId": "crisis-decision-ravine-fire", "actionId": "asegurar-flancos-y-repliegue" },
+    { "sequence": 9, "sceneId": "crisis-decision-housing-defense", "actionId": "defender-desde-posicion-segura" }
+  ],
+  "inheritedState": {
+    "fuelLoad": 45,
+    "fuelContinuity": 25,
+    "operationalAccess": 80,
+    "defensibility": 50,
+    "attackOpportunity": 66
+  },
+  "crisisBranch": "prepared",
+  "result": {
+    "variant": "contained",
+    "evidenceIds": [
+      "fuel-behavior-buffer",
+      "territorial-and-local-access-ready",
+      "safe-attack-envelope",
+      "ravine-position-held-with-safe-retreat",
+      "housing-defense-sustained-selectively"
+    ]
+  },
+  "history": [
+    { "sequence": 1, "type": "session-created", "sessionId": "reference-contained-v1", "schemaVersion": 1, "initialSceneId": "intro-briefing-mission" },
+    { "sequence": 2, "type": "scene-completed", "sceneId": "intro-briefing-mission", "evidenceIds": [] },
+    { "sequence": 3, "type": "scene-transitioned", "fromSceneId": "intro-briefing-mission", "toSceneId": "prevention-inspection-territory-fuel" },
+    { "sequence": 4, "type": "decision-applied", "decisionSequence": 1, "sceneId": "prevention-inspection-territory-fuel", "actionId": "gestionar-restos-poda" },
+    { "sequence": 5, "type": "decision-applied", "decisionSequence": 2, "sceneId": "prevention-inspection-territory-fuel", "actionId": "crear-discontinuidades-vegetales" },
+    { "sequence": 6, "type": "decision-applied", "decisionSequence": 3, "sceneId": "prevention-inspection-territory-fuel", "actionId": "limpiar-margenes-caminos" },
+    {
+      "sequence": 7,
+      "type": "scene-completed",
+      "sceneId": "prevention-inspection-territory-fuel",
+      "evidenceIds": [
+        "pruning-residues-removed-or-processed",
+        "strategic-vegetation-discontinuity-created",
+        "rural-road-margins-cleared"
+      ]
+    },
+    { "sequence": 8, "type": "scene-transitioned", "fromSceneId": "prevention-inspection-territory-fuel", "toSceneId": "prevention-inspection-housing-interface" },
+    { "sequence": 9, "type": "decision-applied", "decisionSequence": 4, "sceneId": "prevention-inspection-housing-interface", "actionId": "podar-ramas-y-retirar-seco" },
+    { "sequence": 10, "type": "decision-applied", "decisionSequence": 5, "sceneId": "prevention-inspection-housing-interface", "actionId": "despejar-accesos" },
+    {
+      "sequence": 11,
+      "type": "scene-completed",
+      "sceneId": "prevention-inspection-housing-interface",
+      "evidenceIds": [
+        "vertical-fuel-continuity-reduced",
+        "fire-engine-access-cleared"
+      ]
+    },
+    {
+      "sequence": 12,
+      "type": "inherited-state-calculated",
+      "state": {
+        "fuelLoad": 45,
+        "fuelContinuity": 25,
+        "operationalAccess": 80,
+        "defensibility": 50,
+        "attackOpportunity": 66
+      },
+      "sourceDecisionSequences": [1, 2, 3, 4, 5],
+      "evidenceIds": [
+        "pruning-residues-removed-or-processed",
+        "strategic-vegetation-discontinuity-created",
+        "rural-road-margins-cleared",
+        "vertical-fuel-continuity-reduced",
+        "fire-engine-access-cleared"
+      ]
+    },
+    { "sequence": 13, "type": "scene-transitioned", "fromSceneId": "prevention-inspection-housing-interface", "toSceneId": "transition-summary-prevention" },
+    { "sequence": 14, "type": "scene-completed", "sceneId": "transition-summary-prevention", "evidenceIds": ["preparedness-summary-produced"] },
+    { "sequence": 15, "type": "scene-transitioned", "fromSceneId": "transition-summary-prevention", "toSceneId": "crisis-decision-first-alert" },
+    { "sequence": 16, "type": "decision-applied", "decisionSequence": 6, "sceneId": "crisis-decision-first-alert", "actionId": "movilizar-y-verificar" },
+    { "sequence": 17, "type": "scene-completed", "sceneId": "crisis-decision-first-alert", "evidenceIds": ["initial-response-mobilized"] },
+    { "sequence": 18, "type": "scene-transitioned", "fromSceneId": "crisis-decision-first-alert", "toSceneId": "crisis-router-causal-map" },
+    {
+      "sequence": 19,
+      "type": "crisis-branch-selected",
+      "branch": "prepared",
+      "nextSceneId": "crisis-decision-emergency-fuel-break",
+      "evidenceIds": ["prepared-branch-selected", "safe-attack-envelope"]
+    },
+    { "sequence": 20, "type": "scene-completed", "sceneId": "crisis-router-causal-map", "evidenceIds": ["prepared-branch-selected"] },
+    { "sequence": 21, "type": "scene-transitioned", "fromSceneId": "crisis-router-causal-map", "toSceneId": "crisis-decision-emergency-fuel-break" },
+    { "sequence": 22, "type": "decision-applied", "decisionSequence": 7, "sceneId": "crisis-decision-emergency-fuel-break", "actionId": "autorizar-maniobra-condicionada" },
+    { "sequence": 23, "type": "scene-completed", "sceneId": "crisis-decision-emergency-fuel-break", "evidenceIds": ["conditioned-emergency-maneuver-authorized"] },
+    { "sequence": 24, "type": "scene-transitioned", "fromSceneId": "crisis-decision-emergency-fuel-break", "toSceneId": "crisis-decision-ravine-fire" },
+    { "sequence": 25, "type": "decision-applied", "decisionSequence": 8, "sceneId": "crisis-decision-ravine-fire", "actionId": "asegurar-flancos-y-repliegue" },
+    { "sequence": 26, "type": "scene-completed", "sceneId": "crisis-decision-ravine-fire", "evidenceIds": ["ravine-position-held-with-safe-retreat"] },
+    { "sequence": 27, "type": "scene-transitioned", "fromSceneId": "crisis-decision-ravine-fire", "toSceneId": "crisis-decision-housing-defense" },
+    { "sequence": 28, "type": "decision-applied", "decisionSequence": 9, "sceneId": "crisis-decision-housing-defense", "actionId": "defender-desde-posicion-segura" },
+    { "sequence": 29, "type": "scene-completed", "sceneId": "crisis-decision-housing-defense", "evidenceIds": ["housing-defense-sustained-selectively"] },
+    { "sequence": 30, "type": "scene-transitioned", "fromSceneId": "crisis-decision-housing-defense", "toSceneId": "ending-result-causal-report" },
+    {
+      "sequence": 31,
+      "type": "scene-completed",
+      "sceneId": "ending-result-causal-report",
+      "evidenceIds": [
+        "fuel-behavior-buffer",
+        "territorial-and-local-access-ready",
+        "safe-attack-envelope",
+        "ravine-position-held-with-safe-retreat",
+        "housing-defense-sustained-selectively"
+      ]
+    },
+    {
+      "sequence": 32,
+      "type": "session-completed",
+      "result": {
+        "variant": "contained",
+        "evidenceIds": [
+          "fuel-behavior-buffer",
+          "territorial-and-local-access-ready",
+          "safe-attack-envelope",
+          "ravine-position-held-with-safe-retreat",
+          "housing-defense-sustained-selectively"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/game-session/reference-context.json
+++ b/tests/fixtures/game-session/reference-context.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "referenceContextId": "vb1-reference-context-v1",
+  "municipalityProfileId": "fictional-ravine-interface-municipality-v1",
+  "weatherProfile": {
+    "id": "dry-windy-daylight-v1",
+    "alertTime": "13:42",
+    "daylight": true,
+    "precipitation": "none",
+    "temperature": "warm",
+    "humidity": "low",
+    "windPattern": "irregular-gusts",
+    "windDirection": "lower-ravine-to-interface",
+    "changesDuringSession": false
+  },
+  "ignitionProfile": {
+    "id": "lower-ravine-rural-track-v1",
+    "location": "lower-ravine-rural-track-edge",
+    "cause": "unconfirmed",
+    "initialObservation": "smoke-column-and-incipient-flames"
+  },
+  "externalCapacityProfileId": "standard-response-capacity-v1",
+  "exposureProfileId": "same-homes-and-positions-v1",
+  "rulesetId": "m1-reference-rules-v1",
+  "gameSessionSchemaVersion": 1,
+  "randomness": "none",
+  "selectionLimits": {
+    "territory": 3,
+    "housing": 2
+  },
+  "firstAlertActionId": "movilizar-y-verificar",
+  "expectedDecisionCount": 9,
+  "expectedVisitedNodeCount": 10,
+  "targetDurationMinutes": {
+    "min": 20,
+    "max": 25
+  }
+}

--- a/tests/fixtures/game-session/reference-overwhelmed.json
+++ b/tests/fixtures/game-session/reference-overwhelmed.json
@@ -1,0 +1,157 @@
+{
+  "schemaVersion": 1,
+  "id": "reference-overwhelmed-v1",
+  "status": "completed",
+  "progress": {
+    "currentSceneId": "ending-result-causal-report",
+    "completedSceneIds": [
+      "intro-briefing-mission",
+      "prevention-inspection-territory-fuel",
+      "prevention-inspection-housing-interface",
+      "transition-summary-prevention",
+      "crisis-decision-first-alert",
+      "crisis-router-causal-map",
+      "crisis-decision-access-blockage",
+      "crisis-decision-ravine-fire",
+      "crisis-decision-crown-fire",
+      "ending-result-causal-report"
+    ]
+  },
+  "decisions": [
+    { "sequence": 1, "sceneId": "prevention-inspection-territory-fuel", "actionId": "gestionar-restos-poda" },
+    { "sequence": 2, "sceneId": "prevention-inspection-territory-fuel", "actionId": "activar-pastoreo-preventivo" },
+    { "sequence": 3, "sceneId": "prevention-inspection-territory-fuel", "actionId": "evaluar-quema-tecnica" },
+    { "sequence": 4, "sceneId": "prevention-inspection-housing-interface", "actionId": "podar-ramas-y-retirar-seco" },
+    { "sequence": 5, "sceneId": "prevention-inspection-housing-interface", "actionId": "separar-copas" },
+    { "sequence": 6, "sceneId": "crisis-decision-first-alert", "actionId": "movilizar-y-verificar" },
+    { "sequence": 7, "sceneId": "crisis-decision-access-blockage", "actionId": "despejar-corredor-operativo" },
+    { "sequence": 8, "sceneId": "crisis-decision-ravine-fire", "actionId": "asegurar-flancos-y-repliegue" },
+    { "sequence": 9, "sceneId": "crisis-decision-crown-fire", "actionId": "replegar-ante-fuego-de-copas" }
+  ],
+  "inheritedState": {
+    "fuelLoad": 25,
+    "fuelContinuity": 35,
+    "operationalAccess": 20,
+    "defensibility": 30,
+    "attackOpportunity": 24
+  },
+  "crisisBranch": "vulnerable",
+  "result": {
+    "variant": "overwhelmed",
+    "evidenceIds": [
+      "fuel-behavior-buffer",
+      "crown-transition-buffer",
+      "access-chain-unavailable",
+      "ravine-position-not-holdable-safe-retreat",
+      "safe-retreat-before-crown-fire"
+    ]
+  },
+  "history": [
+    { "sequence": 1, "type": "session-created", "sessionId": "reference-overwhelmed-v1", "schemaVersion": 1, "initialSceneId": "intro-briefing-mission" },
+    { "sequence": 2, "type": "scene-completed", "sceneId": "intro-briefing-mission", "evidenceIds": [] },
+    { "sequence": 3, "type": "scene-transitioned", "fromSceneId": "intro-briefing-mission", "toSceneId": "prevention-inspection-territory-fuel" },
+    { "sequence": 4, "type": "decision-applied", "decisionSequence": 1, "sceneId": "prevention-inspection-territory-fuel", "actionId": "gestionar-restos-poda" },
+    { "sequence": 5, "type": "decision-applied", "decisionSequence": 2, "sceneId": "prevention-inspection-territory-fuel", "actionId": "activar-pastoreo-preventivo" },
+    { "sequence": 6, "type": "decision-applied", "decisionSequence": 3, "sceneId": "prevention-inspection-territory-fuel", "actionId": "evaluar-quema-tecnica" },
+    {
+      "sequence": 7,
+      "type": "scene-completed",
+      "sceneId": "prevention-inspection-territory-fuel",
+      "evidenceIds": [
+        "pruning-residues-removed-or-processed",
+        "preventive-grazing-completed-in-priority-strips",
+        "professional-line-assessed",
+        "professional-line-feasible"
+      ]
+    },
+    { "sequence": 8, "type": "scene-transitioned", "fromSceneId": "prevention-inspection-territory-fuel", "toSceneId": "prevention-inspection-housing-interface" },
+    { "sequence": 9, "type": "decision-applied", "decisionSequence": 4, "sceneId": "prevention-inspection-housing-interface", "actionId": "podar-ramas-y-retirar-seco" },
+    { "sequence": 10, "type": "decision-applied", "decisionSequence": 5, "sceneId": "prevention-inspection-housing-interface", "actionId": "separar-copas" },
+    {
+      "sequence": 11,
+      "type": "scene-completed",
+      "sceneId": "prevention-inspection-housing-interface",
+      "evidenceIds": [
+        "vertical-fuel-continuity-reduced",
+        "crown-fuel-continuity-reduced"
+      ]
+    },
+    {
+      "sequence": 12,
+      "type": "inherited-state-calculated",
+      "state": {
+        "fuelLoad": 25,
+        "fuelContinuity": 35,
+        "operationalAccess": 20,
+        "defensibility": 30,
+        "attackOpportunity": 24
+      },
+      "sourceDecisionSequences": [1, 2, 3, 4, 5],
+      "evidenceIds": [
+        "pruning-residues-removed-or-processed",
+        "preventive-grazing-completed-in-priority-strips",
+        "professional-line-assessed",
+        "professional-line-feasible",
+        "vertical-fuel-continuity-reduced",
+        "crown-fuel-continuity-reduced",
+        "territorial-vegetation-continuity-present",
+        "rural-road-margins-obstructed",
+        "fire-engine-access-obstructed"
+      ]
+    },
+    { "sequence": 13, "type": "scene-transitioned", "fromSceneId": "prevention-inspection-housing-interface", "toSceneId": "transition-summary-prevention" },
+    { "sequence": 14, "type": "scene-completed", "sceneId": "transition-summary-prevention", "evidenceIds": ["preparedness-summary-produced"] },
+    { "sequence": 15, "type": "scene-transitioned", "fromSceneId": "transition-summary-prevention", "toSceneId": "crisis-decision-first-alert" },
+    { "sequence": 16, "type": "decision-applied", "decisionSequence": 6, "sceneId": "crisis-decision-first-alert", "actionId": "movilizar-y-verificar" },
+    { "sequence": 17, "type": "scene-completed", "sceneId": "crisis-decision-first-alert", "evidenceIds": ["initial-response-mobilized"] },
+    { "sequence": 18, "type": "scene-transitioned", "fromSceneId": "crisis-decision-first-alert", "toSceneId": "crisis-router-causal-map" },
+    {
+      "sequence": 19,
+      "type": "crisis-branch-selected",
+      "branch": "vulnerable",
+      "nextSceneId": "crisis-decision-access-blockage",
+      "evidenceIds": [
+        "operational-access-critical",
+        "access-chain-unavailable",
+        "attack-opportunity-critical"
+      ]
+    },
+    { "sequence": 20, "type": "scene-completed", "sceneId": "crisis-router-causal-map", "evidenceIds": ["vulnerable-branch-selected"] },
+    { "sequence": 21, "type": "scene-transitioned", "fromSceneId": "crisis-router-causal-map", "toSceneId": "crisis-decision-access-blockage" },
+    { "sequence": 22, "type": "decision-applied", "decisionSequence": 7, "sceneId": "crisis-decision-access-blockage", "actionId": "despejar-corredor-operativo" },
+    { "sequence": 23, "type": "scene-completed", "sceneId": "crisis-decision-access-blockage", "evidenceIds": ["temporary-operational-corridor-limited"] },
+    { "sequence": 24, "type": "scene-transitioned", "fromSceneId": "crisis-decision-access-blockage", "toSceneId": "crisis-decision-ravine-fire" },
+    { "sequence": 25, "type": "decision-applied", "decisionSequence": 8, "sceneId": "crisis-decision-ravine-fire", "actionId": "asegurar-flancos-y-repliegue" },
+    { "sequence": 26, "type": "scene-completed", "sceneId": "crisis-decision-ravine-fire", "evidenceIds": ["ravine-position-not-holdable-safe-retreat"] },
+    { "sequence": 27, "type": "scene-transitioned", "fromSceneId": "crisis-decision-ravine-fire", "toSceneId": "crisis-decision-crown-fire" },
+    { "sequence": 28, "type": "decision-applied", "decisionSequence": 9, "sceneId": "crisis-decision-crown-fire", "actionId": "replegar-ante-fuego-de-copas" },
+    { "sequence": 29, "type": "scene-completed", "sceneId": "crisis-decision-crown-fire", "evidenceIds": ["safe-retreat-before-crown-fire"] },
+    { "sequence": 30, "type": "scene-transitioned", "fromSceneId": "crisis-decision-crown-fire", "toSceneId": "ending-result-causal-report" },
+    {
+      "sequence": 31,
+      "type": "scene-completed",
+      "sceneId": "ending-result-causal-report",
+      "evidenceIds": [
+        "fuel-behavior-buffer",
+        "crown-transition-buffer",
+        "access-chain-unavailable",
+        "ravine-position-not-holdable-safe-retreat",
+        "safe-retreat-before-crown-fire"
+      ]
+    },
+    {
+      "sequence": 32,
+      "type": "session-completed",
+      "result": {
+        "variant": "overwhelmed",
+        "evidenceIds": [
+          "fuel-behavior-buffer",
+          "crown-transition-buffer",
+          "access-chain-unavailable",
+          "ravine-position-not-holdable-safe-retreat",
+          "safe-retreat-before-crown-fire"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/game-session-contract.test.ts
+++ b/tests/game-session-contract.test.ts
@@ -15,7 +15,9 @@ const SESSION_FIXTURES = [
   'initial.json',
   'prevention-completed.json',
   'crisis-prepared.json',
-  'completed-contained.json'
+  'completed-contained.json',
+  'reference-contained.json',
+  'reference-overwhelmed.json'
 ] as const;
 
 const TOP_LEVEL_SESSION_FIELDS = new Set([
@@ -48,67 +50,6 @@ function expectContractError(value: unknown, code: GameSessionContractErrorCode)
   expect(result.errors.map((error) => error.code)).toContain(code);
 }
 
-function buildVulnerableCompletedSession(source: MutableJson): MutableJson {
-  const session = clone(source);
-  const sceneMap: Record<string, string> = {
-    'crisis-decision-emergency-fuel-break': 'crisis-decision-access-blockage',
-    'crisis-decision-housing-defense': 'crisis-decision-crown-fire'
-  };
-  const actionMap: Record<string, string> = {
-    'autorizar-maniobra-condicionada': 'despejar-corredor-operativo',
-    'defender-desde-posicion-segura': 'replegar-ante-fuego-de-copas'
-  };
-
-  session.crisisBranch = 'vulnerable';
-  session.progress.completedSceneIds = session.progress.completedSceneIds.map(
-    (sceneId: string) => sceneMap[sceneId] ?? sceneId
-  );
-  session.decisions = session.decisions.map((decision: MutableJson) => ({
-    ...decision,
-    sceneId: sceneMap[decision.sceneId] ?? decision.sceneId,
-    actionId: actionMap[decision.actionId] ?? decision.actionId
-  }));
-
-  session.history = session.history.map((event: MutableJson) => {
-    const mapped = clone(event);
-    if (mapped.sceneId) mapped.sceneId = sceneMap[mapped.sceneId] ?? mapped.sceneId;
-    if (mapped.fromSceneId) mapped.fromSceneId = sceneMap[mapped.fromSceneId] ?? mapped.fromSceneId;
-    if (mapped.toSceneId) mapped.toSceneId = sceneMap[mapped.toSceneId] ?? mapped.toSceneId;
-    if (mapped.actionId) mapped.actionId = actionMap[mapped.actionId] ?? mapped.actionId;
-
-    if (mapped.type === 'crisis-branch-selected') {
-      mapped.branch = 'vulnerable';
-      mapped.nextSceneId = 'crisis-decision-access-blockage';
-      mapped.evidenceIds = ['operational-access-insufficient', 'attack-opportunity-unavailable'];
-    }
-    if (mapped.type === 'scene-completed' && mapped.sceneId === 'ending-result-causal-report') {
-      mapped.evidenceIds = [
-        'fuel-load-high',
-        'fuel-continuity-maintained',
-        'operational-access-insufficient',
-        'attack-opportunity-unavailable',
-        'crown-fire-transition'
-      ];
-    }
-    if (mapped.type === 'session-completed') {
-      mapped.result = {
-        variant: 'overwhelmed',
-        evidenceIds: [
-          'fuel-load-high',
-          'fuel-continuity-maintained',
-          'operational-access-insufficient',
-          'attack-opportunity-unavailable',
-          'crown-fire-transition'
-        ]
-      };
-    }
-    return mapped;
-  });
-
-  session.result = clone(session.history.at(-1).result);
-  return session;
-}
-
 describe('GameSession fixture contract', () => {
   for (const fixtureName of SESSION_FIXTURES) {
     it(`${fixtureName} is valid and survives a JSON round trip`, async () => {
@@ -133,8 +74,8 @@ describe('GameSession fixture contract', () => {
   });
 
   it('represents the vulnerable branch and overwhelmed result without adding fields', async () => {
-    const prepared = await loadJson('completed-contained.json');
-    const vulnerable = buildVulnerableCompletedSession(prepared);
+    const prepared = await loadJson('reference-contained.json');
+    const vulnerable = await loadJson('reference-overwhelmed.json');
 
     expect(validateGameSessionContract(vulnerable)).toEqual({ valid: true, errors: [] });
     expect(vulnerable.crisisBranch).toBe('vulnerable');

--- a/tests/reference-game-sessions.test.ts
+++ b/tests/reference-game-sessions.test.ts
@@ -1,0 +1,205 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  INHERITED_STATE_KEYS,
+  roundTripJson,
+  validateGameSessionContract
+} from './support/game-session-contract.js';
+
+const FIXTURE_DIRECTORY = fileURLToPath(new URL('./fixtures/game-session/', import.meta.url));
+const SESSION_FIELDS = [
+  'schemaVersion',
+  'id',
+  'status',
+  'progress',
+  'decisions',
+  'inheritedState',
+  'crisisBranch',
+  'result',
+  'history'
+].sort();
+
+type JsonObject = Record<string, any>;
+
+async function loadJson(name: string): Promise<JsonObject> {
+  return JSON.parse(await readFile(`${FIXTURE_DIRECTORY}${name}`, 'utf8')) as JsonObject;
+}
+
+const COMMON_PATH = [
+  'intro-briefing-mission',
+  'prevention-inspection-territory-fuel',
+  'prevention-inspection-housing-interface',
+  'transition-summary-prevention',
+  'crisis-decision-first-alert',
+  'crisis-router-causal-map'
+];
+
+const PREPARED_ACTIONS = [
+  'gestionar-restos-poda',
+  'crear-discontinuidades-vegetales',
+  'limpiar-margenes-caminos',
+  'podar-ramas-y-retirar-seco',
+  'despejar-accesos',
+  'movilizar-y-verificar',
+  'autorizar-maniobra-condicionada',
+  'asegurar-flancos-y-repliegue',
+  'defender-desde-posicion-segura'
+];
+
+const VULNERABLE_ACTIONS = [
+  'gestionar-restos-poda',
+  'activar-pastoreo-preventivo',
+  'evaluar-quema-tecnica',
+  'podar-ramas-y-retirar-seco',
+  'separar-copas',
+  'movilizar-y-verificar',
+  'despejar-corredor-operativo',
+  'asegurar-flancos-y-repliegue',
+  'replegar-ante-fuego-de-copas'
+];
+
+describe('canonical reference game sessions', () => {
+  it('pins one deterministic external context outside GameSession', async () => {
+    const context = await loadJson('reference-context.json');
+
+    expect(context).toEqual({
+      schemaVersion: 1,
+      referenceContextId: 'vb1-reference-context-v1',
+      municipalityProfileId: 'fictional-ravine-interface-municipality-v1',
+      weatherProfile: {
+        id: 'dry-windy-daylight-v1',
+        alertTime: '13:42',
+        daylight: true,
+        precipitation: 'none',
+        temperature: 'warm',
+        humidity: 'low',
+        windPattern: 'irregular-gusts',
+        windDirection: 'lower-ravine-to-interface',
+        changesDuringSession: false
+      },
+      ignitionProfile: {
+        id: 'lower-ravine-rural-track-v1',
+        location: 'lower-ravine-rural-track-edge',
+        cause: 'unconfirmed',
+        initialObservation: 'smoke-column-and-incipient-flames'
+      },
+      externalCapacityProfileId: 'standard-response-capacity-v1',
+      exposureProfileId: 'same-homes-and-positions-v1',
+      rulesetId: 'm1-reference-rules-v1',
+      gameSessionSchemaVersion: 1,
+      randomness: 'none',
+      selectionLimits: { territory: 3, housing: 2 },
+      firstAlertActionId: 'movilizar-y-verificar',
+      expectedDecisionCount: 9,
+      expectedVisitedNodeCount: 10,
+      targetDurationMinutes: { min: 20, max: 25 }
+    });
+    expect(roundTripJson(context)).toEqual(context);
+  });
+
+  it('validates and restores both canonical sessions exactly', async () => {
+    const sessions = await Promise.all([
+      loadJson('reference-contained.json'),
+      loadJson('reference-overwhelmed.json')
+    ]);
+
+    for (const session of sessions) {
+      expect(validateGameSessionContract(session)).toEqual({ valid: true, errors: [] });
+      expect(roundTripJson(session)).toEqual(session);
+      expect(Object.keys(session).sort()).toEqual(SESSION_FIELDS);
+      expect(session.decisions).toHaveLength(9);
+      expect(session.progress.completedSceneIds).toHaveLength(10);
+      expect(session.history).toHaveLength(32);
+      expect(session.history.map((event: JsonObject) => event.sequence)).toEqual(
+        Array.from({ length: 32 }, (_, index) => index + 1)
+      );
+    }
+  });
+
+  it('attributes different outcomes to identifiable prevention decisions', async () => {
+    const prepared = await loadJson('reference-contained.json');
+    const vulnerable = await loadJson('reference-overwhelmed.json');
+
+    expect(prepared.decisions.map((decision: JsonObject) => decision.actionId)).toEqual(
+      PREPARED_ACTIONS
+    );
+    expect(vulnerable.decisions.map((decision: JsonObject) => decision.actionId)).toEqual(
+      VULNERABLE_ACTIONS
+    );
+
+    expect(prepared.decisions.slice(0, 5).map((decision: JsonObject) => decision.actionId)).not.toEqual(
+      vulnerable.decisions.slice(0, 5).map((decision: JsonObject) => decision.actionId)
+    );
+    expect(prepared.decisions[5].actionId).toBe('movilizar-y-verificar');
+    expect(vulnerable.decisions[5].actionId).toBe('movilizar-y-verificar');
+    expect(prepared.decisions[7].actionId).toBe('asegurar-flancos-y-repliegue');
+    expect(vulnerable.decisions[7].actionId).toBe('asegurar-flancos-y-repliegue');
+  });
+
+  it('keeps the common graph trunk and proves the expected branch divergence', async () => {
+    const prepared = await loadJson('reference-contained.json');
+    const vulnerable = await loadJson('reference-overwhelmed.json');
+
+    expect(prepared.progress.completedSceneIds.slice(0, 6)).toEqual(COMMON_PATH);
+    expect(vulnerable.progress.completedSceneIds.slice(0, 6)).toEqual(COMMON_PATH);
+    expect(prepared.progress.completedSceneIds.slice(6)).toEqual([
+      'crisis-decision-emergency-fuel-break',
+      'crisis-decision-ravine-fire',
+      'crisis-decision-housing-defense',
+      'ending-result-causal-report'
+    ]);
+    expect(vulnerable.progress.completedSceneIds.slice(6)).toEqual([
+      'crisis-decision-access-blockage',
+      'crisis-decision-ravine-fire',
+      'crisis-decision-crown-fire',
+      'ending-result-causal-report'
+    ]);
+    expect(prepared.crisisBranch).toBe('prepared');
+    expect(vulnerable.crisisBranch).toBe('vulnerable');
+  });
+
+  it('changes every inherited dimension and produces opposite causal results', async () => {
+    const prepared = await loadJson('reference-contained.json');
+    const vulnerable = await loadJson('reference-overwhelmed.json');
+    const changedDimensions = INHERITED_STATE_KEYS.filter(
+      (key) => prepared.inheritedState[key] !== vulnerable.inheritedState[key]
+    );
+
+    expect(Object.keys(prepared.inheritedState)).toEqual(INHERITED_STATE_KEYS);
+    expect(Object.keys(vulnerable.inheritedState)).toEqual(INHERITED_STATE_KEYS);
+    expect(prepared.inheritedState).toEqual({
+      fuelLoad: 45,
+      fuelContinuity: 25,
+      operationalAccess: 80,
+      defensibility: 50,
+      attackOpportunity: 66
+    });
+    expect(vulnerable.inheritedState).toEqual({
+      fuelLoad: 25,
+      fuelContinuity: 35,
+      operationalAccess: 20,
+      defensibility: 30,
+      attackOpportunity: 24
+    });
+    expect(changedDimensions).toHaveLength(5);
+    expect(prepared.result.variant).toBe('contained');
+    expect(vulnerable.result.variant).toBe('overwhelmed');
+    expect(prepared.result.evidenceIds).not.toEqual(vulnerable.result.evidenceIds);
+  });
+
+  it('makes the same ravine decision produce context-dependent evidence', async () => {
+    const prepared = await loadJson('reference-contained.json');
+    const vulnerable = await loadJson('reference-overwhelmed.json');
+    const ravineEvidence = (session: JsonObject): string[] =>
+      session.history.find(
+        (event: JsonObject) =>
+          event.type === 'scene-completed' && event.sceneId === 'crisis-decision-ravine-fire'
+      ).evidenceIds as string[];
+
+    expect(ravineEvidence(prepared)).toEqual(['ravine-position-held-with-safe-retreat']);
+    expect(ravineEvidence(vulnerable)).toEqual([
+      'ravine-position-not-holdable-safe-retreat'
+    ]);
+  });
+});


### PR DESCRIPTION
## Resumen

- materializa un manifest único y determinista para el contexto externo de las dos partidas;
- añade los historiales canónicos completos `contained` y `overwhelmed`;
- compara decisiones, cinco dimensiones, ramas, opciones derivadas, efectos del barranco y resultados;
- incorpora las partidas a la validación exacta de `GameSession` y documenta su consumo directo por #76;
- marca `EV-13-REFERENCE-AUTO` como disponible.

## Estudio

Las partidas comparten municipio, meteorología, ignición, capacidad externa, exposición, reglas, ausencia de azar, primer aviso, barranco, duración y cantidad de decisiones. Difieren en tres elecciones preventivas: la preparada conserva discontinuidad territorial y ambos accesos; la vulnerable mejora carga y copas, pero mantiene bloqueados los accesos.

El contraste cambia las cinco dimensiones:

| Dimensión | Preparada | Vulnerable |
|---|---:|---:|
| `fuelLoad` | 45 | 25 |
| `fuelContinuity` | 25 | 35 |
| `operationalAccess` | 80 | 20 |
| `defensibility` | 50 | 30 |
| `attackOpportunity` | 66 | 24 |

Por eso la misma acción `asegurar-flancos-y-repliegue` sostiene una posición segura en la partida preparada y solo permite repliegue en la vulnerable. Los resultados son, respectivamente, `contained` y `overwhelmed`, sin atribuir el desenlace a una decisión segura ni a variables sociales.

## Validación

- `npm run test:contract`: 43/43
- `npm test`: 46/46
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Closes #47