### PR TITLE
docs: definir validación experta y pruebas ciudadanas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
 - Partida de referencia Municipio preparado: [docs/product/vertical-beta-1-reference-prepared.md](product/vertical-beta-1-reference-prepared.md)
 - Partida de referencia Territorio vulnerable: [docs/product/vertical-beta-1-reference-vulnerable.md](product/vertical-beta-1-reference-vulnerable.md)
 - Comparación y fixtures canónicos de las partidas de referencia: [docs/product/vertical-beta-1-reference-comparison.md](product/vertical-beta-1-reference-comparison.md)
+- Plan de validación experta y ciudadana: [docs/product/vertical-beta-1-validation-plan.md](product/vertical-beta-1-validation-plan.md)
 - Arquitectura de sistema: [docs/architecture/system-architecture.md](architecture/system-architecture.md)
 - Stack y decisiones técnicas: [docs/architecture/tech-stack-and-decisions.md](architecture/tech-stack-and-decisions.md)
 - Dominio y reglas del juego: [docs/domain/game-design-spec.md](domain/game-design-spec.md)

--- a/docs/devops/ci-cd-and-environments.md
+++ b/docs/devops/ci-cd-and-environments.md
@@ -35,5 +35,5 @@ flowchart LR
 - Resumen en Markdown de resultados.
 - Riesgo y rollback por PR.
 
-Un run correcto no autoriza por sí solo publicación pública: también deben cumplirse #10, #76 y las puertas editoriales, operativas y de seguridad de la decisión de alojamiento.
+Un run correcto no autoriza por sí solo publicación pública: también deben cumplirse #76, la revisión experta #99, las pruebas ciudadanas #100 y las puertas editoriales, operativas y de seguridad de la decisión de alojamiento.
 

--- a/docs/devops/publication-and-hosting-decision.md
+++ b/docs/devops/publication-and-hosting-decision.md
@@ -11,7 +11,7 @@ La primera versión publicada será un **piloto controlado para entidades**, acc
 
 El proveedor recomendado es **Render**, mediante un único **Web Service** que construye y ejecuta el repositorio completo. Frontend, rutas HTTP, recursos estáticos y motor permanecen en el mismo proceso Fastify.
 
-La beta pública solo se habilitará después de completar la validación experta y ciudadana de #10 y las puertas de la sección 9.
+La beta pública solo se habilitará después de ejecutar el plan de #10 mediante la revisión experta #99 y las pruebas ciudadanas #100, además de las puertas de la sección 9.
 
 ## 2. Motivo
 
@@ -71,7 +71,7 @@ El servicio gratuito se suspende tras 15 minutos sin tráfico y puede tardar alr
 | Base de datos | `0 USD` mientras no exista persistencia servidor |
 | Total de infraestructura inicial | `7 USD/mes` más dominio opcional |
 
-No se aprueba Postgres por anticipado. Si #10 exige guardar sesiones o consentimiento, se diseñará primero el contrato de datos, retención y privacidad y se presupuestará como recurso separado dentro de Render.
+No se aprueba Postgres por anticipado. El plan #10 mantiene contactos, consentimientos y notas fuera del producto y no activa persistencia de partidas. Si una validación futura exige almacenamiento servidor, se diseñará primero el contrato de datos, retención y privacidad y se presupuestará como recurso separado dentro de Render.
 
 ## 5. Arquitectura de despliegue
 
@@ -135,7 +135,7 @@ Render aporta TLS y mitigación DDoS de plataforma, pero no sustituye autenticac
 |---|---|---|---|
 | Development | Local | Equipo | Desarrollo y pruebas rápidas. |
 | Staging | Render Free o preview temporal | Revisión restringida | Smoke test del commit candidato. Se acepta cold start. |
-| Pilot | Render Starter | Invitación/control de acceso | Sesiones de #10 y entidades colaboradoras. |
+| Pilot | Render Starter | Invitación/control de acceso | Sesiones de #99/#100 y entidades colaboradoras. |
 | Public | Render Starter o superior | Público | Solo después de superar las puertas de publicación. |
 
 No se mantiene producción en Vercel ni se separa frontend/backend. Si el producto supera la capacidad del servicio inicial, se abre una decisión nueva con métricas reales antes de migrar o dividir.
@@ -145,7 +145,7 @@ No se mantiene producción en Vercel ni se separa frontend/backend. Si el produc
 La beta pública requiere simultáneamente:
 
 1. M2 implementada y aceptación integral #76 correcta;
-2. validación experta y ciudadana #10 completada, con bloqueantes resueltos;
+2. plan #10 ejecutado: revisión experta #99 y pruebas ciudadanas #100 completadas, con bloqueantes resueltos;
 3. accesibilidad y comprensión verificadas en los perfiles objetivo;
 4. revisión editorial, licencias, atribuciones, privacidad y aviso educativo aprobados;
 5. control de acceso retirado de forma consciente, no por omisión;
@@ -155,7 +155,7 @@ La beta pública requiere simultáneamente:
 9. presupuesto mensual aprobado y alertas configuradas;
 10. cero secretos o datos personales expuestos en código, logs o payload público.
 
-Un pase técnico de CI no sustituye #10 ni autoriza publicación.
+Un pase técnico de CI no sustituye #99/#100 ni autoriza publicación.
 
 ## 10. Fuera de alcance
 
@@ -164,7 +164,7 @@ Esta decisión no:
 - crea la cuenta de Render, conecta GitHub ni despliega servicios;
 - compra dominio o activa un plan de pago;
 - implementa autenticación, rate limiting, analítica o persistencia;
-- aprueba publicación pública antes de #10 y #76;
+- aprueba publicación pública antes de #76, #99 y #100;
 - adopta Postgres, Redis, Docker, Kubernetes o arquitectura multi-proveedor;
 - define una licencia institucional o un modelo comercial.
 

--- a/docs/product/vertical-beta-1-causal-combinations-validation.md
+++ b/docs/product/vertical-beta-1-causal-combinations-validation.md
@@ -19,7 +19,7 @@ Se usan exactamente tres estados:
 | Estado | Significado | Uso permitido |
 |---|---|---|
 | `validated-product-rule` | Invariante de producto ya acordada, determinista y comprobable en el repositorio. | Forma de datos, precedencia, reproducibilidad y correspondencia con el grafo. No implica aval científico u operativo externo. |
-| `plausible-pending-expert-review` | La dirección causal es coherente con las fuentes técnicas consultadas, pero su formulación para este territorio y contexto debe revisarse en #10. | Afirmaciones sobre comportamiento del fuego, acceso, repliegue, defensa o ataque. |
+| `plausible-pending-expert-review` | La dirección causal es coherente con las fuentes técnicas consultadas, pero su formulación para este territorio y contexto debe revisarse según el plan #10 y registrarse en #99. | Afirmaciones sobre comportamiento del fuego, acceso, repliegue, defensa o ataque. |
 | `gameplay-simplification` | Abstracción deliberada para ofrecer reglas legibles y dos recorridos de beta. | Escala `0..100`, cortes exactos y reducción de un sistema real a cinco dimensiones y dos ramas. |
 
 No se utilizará la etiqueta “validado” sin el sufijo `product-rule`. Una afirmación operativa pendiente no asciende de estado por estar implementada o cubierta por tests.
@@ -147,7 +147,7 @@ Los cortes son parámetros de juego propuestos en #34. Son comprobables, pero no
 
 ## 6. Registro de afirmaciones
 
-| ID | Afirmación sometida a control | Estado | Revisión necesaria en #10 |
+| ID | Afirmación sometida a control | Estado | Revisión necesaria en #99 |
 |---|---|---|---|
 | `PR-001` | Estado y evidencias iguales producen la misma salida. | `validated-product-rule` | No; mantener test de determinismo. |
 | `PR-002` | Un veto crítico precede a toda ventaja parcial. | `validated-product-rule` | Revisar por experto solo la suficiencia de la lista de vetos. |
@@ -179,7 +179,7 @@ Referencias:
 - [NWCG — Lookouts, Communications, Escape Routes, and Safety Zones](https://www.nwcg.gov/publications/pms205/nwcg-glossary-of-wildland-fire-pms-205/lookouts-communications-escape-routes-and-safety-zones-139)
 - [NWCG — S-215 Fire Operations in the Wildland/Urban Interface](https://training.nwcg.gov/dl/s215/s-215-ig.pdf)
 
-## 8. Paquete de revisión para #10
+## 8. Paquete de revisión para #99 según el plan #10
 
 ### Perfiles revisores mínimos
 
@@ -211,7 +211,7 @@ Una ronda queda aprobada cuando:
 - los perfiles preparado y vulnerable siguen siendo reproducibles y diferentes;
 - los textos no presentan `contained` como garantía ni `vulnerable` como predicción universal.
 
-Cerrar #38 deja preparado este paquete. No cierra #10 ni autoriza la publicación de la beta.
+Cerrar #38 deja preparado este paquete. No ejecuta #99/#100 ni autoriza la publicación de la beta.
 
 ## 9. Forma de regla pura
 
@@ -268,7 +268,7 @@ Esta entrega no:
 - define comunicación, evacuación o población vulnerable como causa de rama;
 - garantiza que un tratamiento o una maniobra controle un incendio real;
 - implementa código de producción, textos finales ni las partidas completas;
-- sustituye el proceso de validación experta y ciudadana de #10.
+- sustituye el plan #10 ni las ejecuciones experta #99 y ciudadana #100.
 
 ## 12. Matriz de aceptación de #38
 
@@ -285,7 +285,7 @@ Esta entrega no:
 
 ## 13. Entregas siguientes
 
-- #10 ejecutará la revisión de `OP-*` y las pruebas ciudadanas; permanece abierta como puerta editorial y de publicación;
+- #10 define el método; #99 ejecutará la revisión de `OP-*` y #100 las pruebas ciudadanas como puertas editoriales y de publicación;
 - #39 ordena las combinaciones y evidencias prioritarias en el informe causal final definido en [`vertical-beta-1-causal-report.md`](vertical-beta-1-causal-report.md);
 - #45–#47 convertirán los perfiles y fronteras en recorridos reproducibles;
 - #72 podrá implementar las reglas puras sin duplicar el selector de rama.

--- a/docs/product/vertical-beta-1-causal-report.md
+++ b/docs/product/vertical-beta-1-causal-report.md
@@ -336,7 +336,7 @@ Esta entrega no:
 - introduce comunicación o evacuación como dimensión, rama o selector;
 - modifica el contrato persistido de `GameSession`;
 - implementa UI, catálogos i18n ni reglas de producción;
-- sustituye la validación experta de #10;
+- sustituye la revisión experta #99 definida por el plan #10;
 - fija las partidas canónicas completas, alcance de #44–#47.
 
 ## 12. Matriz de aceptación de #39

--- a/docs/product/vertical-beta-1-reference-comparison.md
+++ b/docs/product/vertical-beta-1-reference-comparison.md
@@ -147,4 +147,4 @@ Los JSON no dependen de HTTP, DOM, Fastify, texto traducido ni reloj real. Por e
 
 ## 10. Exclusiones
 
-Esta entrega no implementa el motor #69, el renderer, las opciones de interfaz ni la aceptación integral #76. Tampoco convierte valores de diseño en garantías científicas o de respuesta real; mantiene las puertas de validación experta de #10.
+Esta entrega no implementa el motor #69, el renderer, las opciones de interfaz ni la aceptación integral #76. Tampoco convierte valores de diseño en garantías científicas o de respuesta real; mantiene la revisión experta #99 definida por el plan #10.

--- a/docs/product/vertical-beta-1-validation-plan.md
+++ b/docs/product/vertical-beta-1-validation-plan.md
@@ -1,0 +1,272 @@
+# Vertical Beta 1 — Plan de validación experta y ciudadana
+
+- Issue de planificación: #10
+- Ejecución experta: #99
+- Ejecución ciudadana: #100
+- Fecha de decisión: 19 de agosto de 2026
+- Estado: plan definido; validación externa no ejecutada
+
+## 1. Decisión y alcance
+
+La Vertical Beta 1 se valida en dos puertas distintas y trazables:
+
+1. **revisión experta**, para comprobar rigor operativo, simplificaciones y mensajes de seguridad;
+2. **pruebas con ciudadanía**, para comprobar aprendizaje, comprensión, duración y accesibilidad.
+
+Cerrar #10 significa que el método está definido. No significa que especialistas o ciudadanía hayan aprobado el producto. La publicación pública requiere ejecutar y cerrar #99 y #100 sobre una versión candidata identificada, además de superar la aceptación técnica #76.
+
+El proceso no pretende certificar una simulación científica ni medir impacto educativo poblacional. La muestra ciudadana es cualitativa y sirve como puerta de producto: detecta problemas, permite iterar y aporta evidencia suficiente para decidir si la beta puede exponerse a un público más amplio.
+
+## 2. Preguntas de validación
+
+La validación debe responder con evidencia a estas preguntas:
+
+1. ¿Las relaciones entre prevención, estado heredado, crisis y resultado son plausibles y están formuladas con límites correctos?
+2. ¿El contenido evita convertir una regla de juego en una garantía científica, una predicción o una orden operativa real?
+3. ¿Una persona entiende sin ayuda que decisiones preventivas diferentes cambian las condiciones de la emergencia?
+4. ¿Las consecuencias se atribuyen a decisiones anteriores y no a azar, puntuaciones ocultas o un guion predeterminado?
+5. ¿Las opciones, consecuencias y el informe causal se comprenden con el contexto disponible?
+6. ¿Las partidas preparada y vulnerable se perciben como diferentes por causas identificables?
+7. ¿El recorrido se completa en el tiempo objetivo sin confusión, abandono ni barreras de acceso?
+
+## 3. Orden y puertas
+
+```text
+#10 plan integrado
+  -> #99 revisión experta documental inicial
+  -> #76 candidato ejecutable y aceptación técnica
+  -> #99 dictamen experto final sobre versión candidata
+  -> #100 ronda ciudadana diagnóstica
+  -> correcciones y nueva versión
+  -> #100 ronda ciudadana final
+  -> decisión editorial de publicación
+```
+
+No se expone a participantes un candidato con un hallazgo experto de seguridad bloqueante. Un cambio posterior que altere una afirmación revisada, un texto de seguridad, una regla causal o una escena invalida solo las firmas afectadas, que deben repetirse sobre el nuevo commit.
+
+## 4. Revisión experta
+
+### 4.1 Perfiles mínimos
+
+Debe existir al menos una firma independiente para cada dominio:
+
+| Dominio | Experiencia requerida | Foco de revisión |
+|---|---|---|
+| Prevención y comportamiento del fuego | Gestión de combustibles, prevención o análisis de incendios forestales | Carga, continuidad, tratamientos, interfaz y límites de las simplificaciones. |
+| Protección civil y evacuación | Planificación o coordinación de emergencias | Autoridad, alertas, evacuación/confinamiento, coordinación territorial y población expuesta. |
+| Operaciones de extinción | Mando, seguridad o intervención en incendios forestales | Acceso, repliegue, línea preventiva, defensa de viviendas y oportunidad de ataque. |
+| Comunicación pública y 112 | Comunicación de emergencias o centro coordinador | Canales oficiales, rumores, llamadas al 112, incertidumbre y mensajes accionables. |
+| Población vulnerable e interfaz | Servicios sociales, accesibilidad, autoprotección o interfaz urbano-forestal | Apoyos, movilidad, lenguaje no estigmatizante, vivienda y necesidades de acceso. |
+
+Una persona puede cubrir como máximo dos dominios si acredita ambos. Las cinco decisiones se registran por separado. Producto y desarrollo pueden observar y responder, pero no sustituyen las firmas externas.
+
+### 4.2 Paquete de revisión
+
+Cada revisor recibe un manifiesto inmutable con:
+
+- commit, URL del candidato, fecha, idioma y navegador objetivo;
+- catálogo y grafo de los 12 nodos oficiales;
+- matriz, combinaciones e informe causal;
+- afirmaciones `OP-*`, `SIM-*` y estados de validación;
+- dos partidas y fixtures canónicos;
+- textos, opciones, consecuencias e informe final visibles;
+- aviso educativo y límites de uso del producto;
+- formulario de dictamen y registro de hallazgos.
+
+La revisión toma como referencia territorial el INFOCA y las recomendaciones oficiales vigentes del Gobierno de Canarias. Las fuentes sostienen el contraste; no convierten al equipo en autoridad operativa.
+
+### 4.3 Método
+
+1. **Declaración:** identidad, perfil, dominio, afiliación y posibles conflictos.
+2. **Revisión individual:** recorrido de ambos fixtures y decisión por cada afirmación o escena asignada.
+3. **Registro:** `accept`, `adjust` o `reject`, con justificación, evidencia, severidad y versión.
+4. **Contraste conjunto:** resolver contradicciones entre dominios sin borrar el dictamen original.
+5. **Corrección:** cada bloqueante o mayor se convierte en issue con responsable y prueba de cierre.
+6. **Revisión dirigida:** la persona competente reevalúa únicamente las filas afectadas.
+7. **Acta:** cinco firmas y decisión `approved`, `approved-with-non-blocking-follow-up` o `rejected`.
+
+El silencio no cuenta como aprobación. Una afirmación `plausible-pending-expert-review` solo cambia de estado cuando el acta identifica decisión, persona, fecha y commit.
+
+## 5. Pruebas con ciudadanía
+
+### 5.1 Muestra
+
+Se realizan dos rondas moderadas de **seis personas adultas** cada una. La primera es diagnóstica; la segunda evalúa el candidato corregido. Si la evidencia es contradictoria se añade otra ronda pequeña, no se amplía retrospectivamente una ronda cerrada.
+
+Cada ronda debe incluir:
+
+- dos personas de 18–34 años, dos de 35–59 y dos de 60 o más;
+- al menos tres personas que vivan o hayan vivido en territorio rural o de interfaz urbano-forestal;
+- al menos dos personas con competencia digital baja o media-baja;
+- al menos una persona con discapacidad, tecnología de apoyo o necesidad de adaptación;
+- uso representativo de móvil y escritorio;
+- diversidad de género y de experiencia previa con incendios.
+
+No se recluta al equipo, especialistas del panel ni personas que hayan diseñado el contenido como sustitutos de ciudadanía. La primera validación excluye menores para no introducir un protocolo adicional de consentimiento; una versión educativa dirigida a menores necesitará una ronda específica.
+
+La guía de GOV.UK sitúa habitualmente las rondas de entrevistas o usabilidad entre cuatro y ocho participantes y recomienda incluir personas con discapacidad o que necesitan apoyo. Se eligen seis para permitir variedad sin convertir una prueba cualitativa en una encuesta.
+
+### 5.2 Reparto de partidas
+
+En cada ronda, tres participantes recorren la partida preparada y tres la vulnerable usando decisiones de referencia presentadas como tareas, no como respuestas correctas. Después se muestra a cada persona el informe final canónico de la ruta alternativa para comprobar si distingue las causas y consecuencias de ambos recorridos.
+
+Los participantes no reciben antes de jugar una explicación de la relación causal que se quiere medir. La persona moderadora puede resolver un problema técnico, pero no interpretar opciones ni explicar el modelo.
+
+### 5.3 Guion de sesión
+
+| Bloque | Tiempo orientativo | Actividad |
+|---|---:|---|
+| Bienvenida | 5 min | Información, consentimiento, derecho a parar y necesidades de acceso. |
+| Pretest | 5 min | Preguntas abiertas sobre prevención y consecuencias, sin enseñar el modelo. |
+| Inicio | 2 min | Tarea y técnica de pensar en voz alta; no se explican controles. |
+| Partida | 20–25 min | Recorrido completo; tiempos, errores, ayudas y comentarios observados. |
+| Comparación | 5 min | Lectura del informe alternativo y comparación entre partidas. |
+| Postest | 10 min | Comprensión causal, atribución, opciones, informe y transferencia. |
+| Accesibilidad y cierre | 5–10 min | Barreras, confianza, malestar, comentarios y recordatorio de retirada. |
+
+Se ejecuta antes un piloto interno para probar el guion y los instrumentos. El piloto no se mezcla con la evidencia ciudadana.
+
+### 5.4 Preguntas antes de jugar
+
+1. ¿Qué cosas pueden cambiar las consecuencias de un incendio antes de que empiece?
+2. Si dos municipios afrontan el mismo incendio, ¿por qué podrían obtener resultados diferentes?
+3. ¿Qué información necesitarías para decidir durante una emergencia?
+4. ¿Qué esperarías aprender de una experiencia como esta?
+
+Las respuestas se codifican después; no se corrigen durante la sesión.
+
+### 5.5 Preguntas después de jugar
+
+1. Cuéntame con tus palabras qué ocurrió y por qué terminó así.
+2. ¿Qué decisión preventiva tuvo una consecuencia durante la crisis? Indica la decisión, el cambio y la consecuencia.
+3. ¿Hubo algo que pareciera azaroso, predeterminado o difícil de relacionar con tus decisiones?
+4. ¿Qué opción o texto te resultó más difícil de entender?
+5. ¿Qué te enseñó el informe final que no estuviera claro durante la partida?
+6. Al comparar ambos informes, ¿qué cambió, qué decisión lo causó y qué no puede concluirse sobre un incendio real?
+7. Si volvieras a jugar, ¿qué cambiarías y qué efecto esperarías?
+8. ¿Encontraste una barrera de lectura, navegación, control, tiempo o concentración?
+
+## 6. Métricas y criterios de aceptación
+
+Los porcentajes se expresan también como recuentos porque seis personas no permiten inferencias estadísticas. La puerta se evalúa sobre la ronda final; la primera ronda sirve para encontrar y corregir problemas.
+
+| Señal | Registro | Puerta de ronda final |
+|---|---|---|
+| Comprensión prevención–crisis | Rúbrica `0` sin relación, `1` relación genérica, `2` cadena decisión–estado–consecuencia correcta. | Al menos 5 de 6 alcanzan `2`; quien ya partía de `2` debe mantenerlo. |
+| Atribución | Causa declarada del resultado. | Al menos 5 de 6 lo atribuyen a decisiones anteriores, no a azar o guion fijo. |
+| Informe causal | Número de cadenas correctas identificadas. | Al menos 5 de 6 identifican dos cadenas correctas. |
+| Diferencia entre partidas | Comparación del informe alternativo. | Al menos 5 de 6 distinguen ruta, resultado y una causa preventiva. |
+| Comprensión de opciones | Paráfrasis antes de confirmar y ayudas solicitadas. | Ninguna opción crítica induce una interpretación peligrosa; al menos 5 de 6 completan sin explicación del moderador. |
+| Duración | Tiempo desde inicio de partida hasta informe. | Mediana no superior a 25 minutos; las adaptaciones no cuentan como fallo de tiempo. |
+| Finalización | Cierre, abandono y motivo. | 6 de 6 completan o no existe abandono causado por bloqueo del producto. |
+| Accesibilidad | Barreras observadas y tareas con apoyo. | Cero bloqueantes o mayores abiertos; recorrido completo por teclado y con las ayudas representadas. |
+| Transferencia prudente | Respuesta sobre límites del juego. | Al menos 5 de 6 no interpretan `contained` como garantía ni `overwhelmed` como predicción universal. |
+
+La beta no se aprueba por promediar señales. Un único hallazgo con riesgo de daño, instrucción equivocada o exclusión completa puede bloquear aunque el resto de métricas pase.
+
+## 7. Accesibilidad
+
+La revisión combina comprobación técnica de WCAG 2.2 AA y evaluación humana. Como mínimo se prueba:
+
+- recorrido completo por teclado, foco visible y orden coherente;
+- ampliación al 200 % sin pérdida de contenido o acciones;
+- ausencia de información dependiente solo de color, sonido, hover o memoria;
+- objetivos, errores, contadores y consecuencias con nombres comprensibles;
+- tamaño y separación de controles en móvil;
+- movimiento reducido;
+- lectura con la tecnología de apoyo representada en la muestra;
+- tiempo flexible y posibilidad de pausa sin penalizar la lectura.
+
+Superar una herramienta automática no sustituye las tareas manuales ni la participación de personas con discapacidad. Las necesidades de acceso se solicitan sin exigir diagnósticos médicos.
+
+## 8. Consentimiento, bienestar y datos
+
+Antes de reclutar deben aprobarse una hoja de información y un consentimiento comprensibles. Cada participante puede omitir preguntas, pedir una pausa o retirarse sin justificarlo. El contenido puede recordar una emergencia vivida; la persona moderadora detiene la sesión ante malestar y no insiste en obtener evidencia.
+
+Reglas mínimas:
+
+- usar códigos `P01`–`P12` en notas, métricas, commits e issues;
+- separar datos de contacto y consentimiento de los hallazgos;
+- no registrar diagnósticos, direcciones, experiencias traumáticas detalladas ni decisiones personales innecesarias;
+- hacer audio o vídeo solo con permiso opcional y finalidad declarada;
+- eliminar contactos y grabaciones como máximo 30 días después de cerrar compensación y análisis;
+- conservar únicamente notas anonimizadas y métricas agregadas necesarias para justificar la decisión;
+- no incluir datos personales en GitHub, logs de la aplicación ni payloads de prueba.
+
+Si la entidad responsable necesita otra retención, debe aprobarla antes del reclutamiento y comunicarla a participantes. El plan no activa analítica ni persistencia de sesiones en el producto.
+
+## 9. Registro y priorización de hallazgos
+
+Cada hallazgo utiliza esta estructura:
+
+```text
+findingId
+source: expert | citizen | accessibility
+participantOrReviewerCode
+observedVersion
+sceneIds
+claimIds
+observation
+evidence
+impact
+severity: blocker | major | moderate | improvement
+owner
+issueUrl
+status: open | fixed | accepted-risk | rejected
+verificationVersion
+verifiedBy
+```
+
+| Severidad | Criterio | Tratamiento |
+|---|---|---|
+| `blocker` | Puede inducir una actuación peligrosa, contradice autoridad operativa, expone datos o impide completar una tarea crítica. | Parar la ronda o publicación, abrir issue inmediata y repetir la evidencia afectada. |
+| `major` | Rompe el aprendizaje principal, causa atribución errónea repetida o excluye un perfil objetivo. | Corregir antes de la siguiente ronda o del dictamen final. |
+| `moderate` | Genera fricción o confusión recuperable sin falsear el mensaje principal. | Priorizar con producto y verificar si se modifica. |
+| `improvement` | Preferencia o mejora sin impacto demostrado en seguridad, comprensión o acceso. | Backlog; no bloquea. |
+
+Dos observaciones similares pueden agruparse, conservando sus evidencias. Una sola observación puede ser bloqueante por impacto. `accepted-risk` exige justificación pública, responsable y fecha de revisión; no está permitido para `blocker`.
+
+## 10. Evidencias y decisión final
+
+#99 y #100 deben producir, sin datos personales innecesarios:
+
+- manifiesto de versión;
+- matriz experta y acta de cinco dominios;
+- guion y piloto;
+- tabla agregada de muestra, tareas y métricas;
+- registro de hallazgos e issues derivadas;
+- evidencia de corrección y revalidación;
+- decisión `approved`, `approved-with-non-blocking-follow-up` o `rejected`.
+
+La publicación requiere simultáneamente:
+
+1. #76 correcto sobre el mismo candidato;
+2. #99 aprobado y sin `blocker`/`major` abierto;
+3. #100 con todas las puertas de la ronda final superadas;
+4. cualquier cambio posterior relevante revalidado;
+5. responsable editorial identificado y versión aprobada registrada.
+
+## 11. Fuentes de método y contexto
+
+- [GOV.UK — Plan user research for your service](https://www.gov.uk/service-manual/user-research/plan-user-research-for-your-service)
+- [GOV.UK — Plan a round of user research](https://www.gov.uk/service-manual/user-research/plan-round-of-user-research)
+- [GOV.UK — Finding participants for user research](https://www.gov.uk/service-manual/user-research/find-user-research-participants)
+- [GOV.UK — Managing user research data and participant privacy](https://www.gov.uk/service-manual/user-research/managing-user-research-data-participant-privacy)
+- [W3C — Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/)
+- [W3C — Cognitive Accessibility](https://www.w3.org/WAI/cognitive/)
+- [Gobierno de Canarias — INFOCA](https://www.gobiernodecanarias.org/emergencias/planes-de-emergencias/infoca.html)
+- [Gobierno de Canarias — recomendaciones a la población por riesgo de incendios forestales](https://www.gobiernodecanarias.org/cmsgob1/export/sites/emergencias/descargas/alertas/ANEXO-V-RECOMENDACIONES-POBLACION-RIESGO-INFOCA.PDF)
+
+Estas fuentes orientan método, accesibilidad y contraste territorial. Los umbrales de aceptación son decisiones de producto para esta beta y deben revisarse si cambia el público, el idioma o el formato de sesión.
+
+## 12. Matriz de aceptación de #10
+
+| Criterio | Evidencia | Estado |
+|---|---|---|
+| Perfiles revisores | Cinco dominios, sección 4.1 | Cumplido |
+| Muestra inicial | Dos rondas de seis con cuotas inclusivas, sección 5.1 | Cumplido |
+| Guion de prueba | Secuencia, tiempos y reparto, secciones 5.2–5.3 | Cumplido |
+| Preguntas antes y después | Secciones 5.4–5.5 | Cumplido |
+| Métricas y aceptación | Recuentos y puertas, sección 6 | Cumplido |
+| Registro y priorización | Esquema y severidades, sección 9 | Cumplido |
+| Ejecución trazable | Issues #99 y #100, secciones 3 y 10 | Cumplido |

--- a/docs/project/inventario-actual.md
+++ b/docs/project/inventario-actual.md
@@ -45,9 +45,9 @@ El dominio técnico oficial será ligero y estará centrado en una **`GameSessio
 | Objetivo educativo | Existe y es aprovechable | Decisión de producto | Mostrar que la prevención de invierno modifica las condiciones y consecuencias de la emergencia de verano. |
 | Estructura temporal | Existe y es aprovechable | `campaign.ts`, inspecciones y escenarios | Invierno y verano no son modos separados, sino dos momentos causales de una misma partida. |
 | Vertical Beta 1 | Existe y es aprovechable | `docs/product/vertical-beta-1.md` | Recorrido oficial cerrado para la siguiente fase. |
-| Duración objetivo | Existe, pero necesita validación | Definición de la beta | Referencia inicial: 20–25 minutos. Debe comprobarse con usuarios. |
-| KPIs | Es solo documentación o propuesta | Documentación de producto | Falta convertirlos en métricas concretas de validación. |
-| Modelo de publicación y explotación | Definido; despliegue aún no ejecutado | [`publication-and-hosting-decision.md`](../devops/publication-and-hosting-decision.md), #9 | Piloto controlado en un único Render Web Service; publicación pública condicionada a #10 y #76. |
+| Duración objetivo | Criterio definido; validación pendiente | [`vertical-beta-1-validation-plan.md`](../product/vertical-beta-1-validation-plan.md), #10 | Mediana final no superior a 25 minutos; se medirá en #100. |
+| KPIs | Criterios concretos definidos; medición pendiente | [`vertical-beta-1-validation-plan.md`](../product/vertical-beta-1-validation-plan.md) | Comprensión, atribución, informe, diferencia, duración, finalización y accesibilidad se medirán en #100. |
+| Modelo de publicación y explotación | Definido; despliegue aún no ejecutado | [`publication-and-hosting-decision.md`](../devops/publication-and-hosting-decision.md), #9 | Piloto controlado en Render; publicación pública condicionada a #76, #99 y #100. |
 
 ### Recorrido oficial de la Vertical Beta 1
 
@@ -110,7 +110,7 @@ Dos partidas con decisiones preventivas diferentes deben producir condiciones, d
 | Modelo unificado de escenas | Es solo documentación o propuesta | `docs/architecture/decision-game-domain.md` | Crear una unión tipada para decisiones, inspecciones, resúmenes, rutas y selección de acciones. |
 | Grafo narrativo completo | Falta implementar | `nextLogic`, `routeLogic` parciales | Debe documentarse el flujo oficial y sus bifurcaciones. |
 | Coherencia de IDs y categorías | Existe, pero necesita revisión | Historial de renombrados | Hay que localizar duplicados, escenarios huérfanos y saltos de numeración. |
-| Validación experta | Falta implementar | Issue #10 | Debe definirse quién revisa el contenido operativo y cómo queda aprobado. |
+| Validación experta | Plan definido; ejecución pendiente | [`vertical-beta-1-validation-plan.md`](../product/vertical-beta-1-validation-plan.md), #99 | Cinco dominios, revisión por afirmación, acta y firma sobre versión candidata. |
 
 ## 3. Motor de juego y dominio
 
@@ -233,7 +233,7 @@ Operaciones principales previstas:
 | Tests end-to-end | Falta implementar | No Playwright activo | Cubrir al menos dos partidas preventivas diferentes. |
 | Typecheck y build | Existe y es aprovechable | Scripts disponibles | Deben ejecutarse en CI. |
 | CI | Falta implementar | Sin checks activos verificados | Añadir GitHub Actions para typecheck, build y tests. |
-| Validación del objetivo educativo | Falta implementar | Issue #10 | Comprobar que el usuario entiende la relación prevención–impacto. |
+| Validación del objetivo educativo | Plan definido; ejecución pendiente | [`vertical-beta-1-validation-plan.md`](../product/vertical-beta-1-validation-plan.md), #100 | Dos rondas de seis personas con criterios de comprensión, duración y accesibilidad. |
 | Validación editorial automatizada | Falta implementar | No localizada | Comprobar IDs, claves i18n, textos ausentes y divergencias antes de integrar cambios. |
 
 ## 10. Despliegue y operación
@@ -256,7 +256,7 @@ Operaciones principales previstas:
 | Decisión de dominio del juego | Existe y es aprovechable | `docs/architecture/decision-game-domain.md` | Define el dominio ligero centrado en partida y el plan de retirada del código de ejemplo. |
 | Backlog previo | Existe, pero necesita revisión | `docs/project/backlog-pendiente.md` | Está orientado a una arquitectura más ambiciosa. |
 | Material histórico | Existe, pero necesita revisión | `docs/legacy`, `buzon` | Separar vigente, referencia y archivo. |
-| Issues como gestión | Existe, pero necesita revisión | Issues #9 y #10 | Ya se registran decisiones diferidas; falta trasladar el roadmap técnico cuando se apruebe. |
+| Issues como gestión | Existe y es aprovechable | Issues #9, #10, #99 y #100 | Decisiones de publicación y validación documentadas; ejecución externa separada y trazable. |
 | Criterios de terminado | Es solo documentación o propuesta | Plantillas | Aplicarlos a los próximos hitos. |
 
 ---
@@ -274,12 +274,12 @@ Operaciones principales previstas:
 9. **Dominio:** modelo ligero centrado en `GameSession`; reglas TypeScript puras; escenas unificadas; `campaign.ts` como flujo; retirada de `FireIncident` y `/fires/active`.
 10. **Simulación física, MapLibre y PostGIS:** fuera del alcance de la beta.
 
-## Decisiones aún pendientes antes del roadmap
+## Decisiones externas al roadmap técnico
 
-1. **Publicación — Issue #9:** formato de explotación y proveedor inicial.
-2. **Validación — Issue #10:** quién revisará el rigor operativo y cómo se probará el aprendizaje con ciudadanía.
+1. **Publicación — Issue #9:** decisión definida; despliegue y exposición aún no ejecutados.
+2. **Validación — Issue #10:** plan definido; revisión experta #99 y pruebas ciudadanas #100 pendientes.
 
-Estas decisiones están registradas como incidencias y no bloquean la especificación ni la implementación inicial del dominio del juego.
+La ejecución de #99/#100 no bloquea la implementación inicial del dominio, pero sí la aprobación editorial y la publicación pública.
 
 ## Vacíos prioritarios
 

--- a/docs/project/m1-acceptance-evidence.md
+++ b/docs/project/m1-acceptance-evidence.md
@@ -28,7 +28,7 @@ La matriz responde a cuatro preguntas:
 
 Una misma persona puede ejercer más de un rol, pero las firmas técnica y editorial se registran por separado. Si una persona delega, #43 debe identificar la cuenta sustituta antes de evaluar la primera fila de ese rol; no se acepta una firma anónima como “equipo”.
 
-Esta asignación no sustituye revisores especialistas de incendios. Su designación y trabajo pertenecen a #10 y bloquean la aprobación editorial/publicación cuando proceda, no la definición estructural de M1.
+Esta asignación no sustituye revisores especialistas de incendios. El método pertenece al plan #10 y su designación y trabajo a #99; bloquean la aprobación editorial/publicación cuando proceda, no la definición estructural de M1.
 
 ## 3. Severidad
 
@@ -179,9 +179,9 @@ G1–G6 disponen de `EV-01..EV-14`; G7 necesita la auditoría cruzada final de #
 
 | Trabajo | Clasificación | Motivo | Seguimiento |
 |---|---|---|---|
-| Validación experta de afirmaciones operativas y pruebas con ciudadanía | Puerta editorial/de publicación posterior; no bloquea el diseño estructural de M1 ni iniciar implementación. | Requiere perfiles externos y sesiones que no forman parte de la especificación ejecutable. | #10 |
+| Validación experta de afirmaciones operativas y pruebas con ciudadanía | Puerta editorial/de publicación posterior; no bloquea el diseño estructural de M1 ni iniciar implementación. | El plan está en #10; requiere perfiles externos y sesiones que no forman parte de la especificación ejecutable. | #99 y #100 |
 | Implementación del catálogo, motor, flujo, UI, separación de contenido, migración i18n y aceptación integral | Entrega M2, no evidencia de M1. | M1 define contratos objetivo; exigir el runtime nuevo para cerrar M1 produciría una dependencia circular. | #67–#76 |
-| Ajustes derivados de pruebas expertas o ciudadanas que no cambien contratos estructurales | `post-m1-improvement`. | Pueden versionarse sobre la implementación; si cambian un criterio G*, M1 debe reabrirse o revalidarse. | Issue específica creada desde #10 |
+| Ajustes derivados de pruebas expertas o ciudadanas que no cambien contratos estructurales | `post-m1-improvement`. | Pueden versionarse sobre la implementación; si cambian un criterio G*, M1 debe reabrirse o revalidarse. | Issue específica creada desde #99/#100 |
 
 Una mejora posterior nunca transforma en aceptable un `fail` de G1–G7.
 
@@ -193,7 +193,7 @@ Esta entrega no:
 - define la combinación final de puertas que formará la DoR de #42;
 - crea los artefactos de #44–#47 o #43;
 - exige implementar #67–#76 para cerrar M1;
-- declara realizada la validación experta de #10;
+- declara realizada la revisión experta #99 o las pruebas ciudadanas #100;
 - asigna automáticamente personas en GitHub ni envía solicitudes de revisión;
 - permite sustituir evidencia técnica por aprobación editorial, o al contrario.
 

--- a/docs/project/m1-acceptance-gates.md
+++ b/docs/project/m1-acceptance-gates.md
@@ -150,7 +150,7 @@ Esta entrega no:
 - fija la Definition of Ready de M2;
 - sustituye las partidas y fixtures de #44–#47;
 - exige que el runtime actual implemente ya la especificación objetivo de M1;
-- evalúa la aprobación editorial o de publicación dependiente de #10.
+- evalúa la aprobación editorial o de publicación dependiente del plan #10 y su ejecución en #99/#100.
 
 ## 13. Matriz de aceptación de #40
 

--- a/docs/project/m2-definition-of-ready.md
+++ b/docs/project/m2-definition-of-ready.md
@@ -85,7 +85,7 @@ M2 no se bloquea por una corrección posterior de ortografía, puntuación, gram
 - tiene issue o PR propia, clasificación `editorial-safe` y revisión de `R-EDITORIAL`;
 - no invalida ninguna fila `G*`, firma ni evidencia aceptada.
 
-La validación experta o ciudadana de #10 continúa siendo una puerta editorial o de publicación posterior. Solo bloquea o revoca esta DoR si descubre un cambio necesario que afecte a la estructura o a una fila `G*`.
+El plan #10 se ejecuta mediante la revisión experta #99 y las pruebas ciudadanas #100 como puertas editoriales o de publicación posteriores. Solo bloquean o revocan esta DoR si descubren un cambio necesario que afecte a la estructura o a una fila `G*`.
 
 ## 7. Cambios que bloquean o revocan Ready
 


### PR DESCRIPTION
## Resumen

- define cinco perfiles de revisión experta, paquete versionado, dictamen por afirmación y acta final;
- fija dos rondas ciudadanas de seis personas con cuotas de edad, territorio, competencia digital, accesibilidad y dispositivos;
- incluye guion, pretest, postest, comparación de partidas y protocolo de moderación;
- convierte comprensión, atribución, informe causal, diferencia entre recorridos, duración, finalización y accesibilidad en puertas verificables;
- define consentimiento, bienestar, minimización de datos, retención y registro priorizado de hallazgos;
- separa la planificación #10 de la ejecución real: revisión experta #99 y pruebas ciudadanas #100;
- actualiza las referencias de publicación, M1/M2 e inventario para que cerrar #10 no se confunda con una validación ya realizada.

## Impacto

El cierre de #10 aprueba el método, no la beta. La publicación pública continúa bloqueada por #76, #99 y #100.

## Validación

- `npm test` — 46 tests correctos
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- enlaces Markdown relativos comprobados

Closes #10