### PR TITLE
fix: corregir vulnerabilidades altas de producción

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "juegoincendio-prototype",
       "version": "0.1.0",
       "dependencies": {
-        "fastify": "^5.2.0"
+        "fastify": "^5.12.1"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1382,9 +1382,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
-      "integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
+      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
       "funding": [
         {
           "type": "github",
@@ -1403,16 +1403,56 @@
         "@fastify/proxy-addr": "^5.0.0",
         "abstract-logging": "^2.0.1",
         "avvio": "^9.0.0",
-        "fast-json-stringify": "^6.0.0",
-        "find-my-way": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
-        "pino": "^10.1.0",
-        "process-warning": "^5.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.1.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",
         "toad-cache": "^3.7.0"
       }
+    },
+    "node_modules/fastify/node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fastify/node_modules/fast-uri": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -1442,9 +1482,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.4.0.tgz",
-      "integrity": "sha512-5Ye4vHsypZRYtS01ob/iwHzGRUDELlsoCftI/OZFhcLs1M0tkGPcXldE80TAZC5yYuJMBPJQQ43UHlqbJWiX2w==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.8.0.tgz",
+      "integrity": "sha512-JtyUgATO7qxRp2zKhrmWof74Mqxc1ikbwpwMY97p8ipuTj2QtreA4gK2JNAF6SOqqHnYYkwMUvsgQVi2AJxIyw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1717,9 +1757,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
       "funding": [
         {
           "type": "github",
@@ -1837,9 +1877,9 @@
       }
     },
     "node_modules/safe-regex2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
-      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
       "funding": [
         {
           "type": "github",
@@ -1853,6 +1893,9 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safe-stable-stringify": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "fastify": "^5.2.0"
+    "fastify": "^5.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",


### PR DESCRIPTION
## Qué cambia

- Actualiza Fastify de 5.7.4 a 5.12.1 sin cambiar de versión mayor.
- Actualiza transitivamente `find-my-way` a 9.8.0.
- Actualiza `fast-uri` fuera de los rangos vulnerables.
- Regenera el lockfile sin usar `npm audit fix --force`.

## Motivo y causa raíz

El lockfile resolvía versiones incluidas en avisos de seguridad de Fastify, su router y el parser de URI. El rango directo histórico `^5.2.0` permitía mantener un árbol vulnerable ya fijado en el lockfile.

## Impacto

El árbol de dependencias de producción pasa de 3 vulnerabilidades altas a 0. No hay cambios intencionados en el contrato funcional de la aplicación ni una migración de versión mayor.

## Validación

- `npm audit --omit=dev`: 0 vulnerabilidades
- `npm ls fastify find-my-way fast-uri --all`: árbol válido
- `npm test`: 46/46
- `npm run typecheck`: correcto
- `npm run build`: correcto
- `git diff --check`: correcto

La auditoría completa aún identifica alertas exclusivas de desarrollo; se documentan en #104 para gestionarlas en una incidencia independiente.

Closes #104