### PR TITLE
ci: actualizar GitHub Actions al runtime Node.js 24

### DIFF
--- a/.github/workflows/game-session-contract.yml
+++ b/.github/workflows/game-session-contract.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Qué cambia

- Actualiza `actions/checkout` de v4 a v7.
- Actualiza `actions/setup-node` de v4 a v7.

## Motivo

Las versiones v4 empaquetan runtime Node.js 20, ya obsoleto, y GitHub Actions las estaba forzando temporalmente a Node.js 24. Las versiones v7 oficiales declaran directamente `runs.using: node24`.

## Compatibilidad

El workflow usa un runner alojado `ubuntu-latest`, el trigger ordinario `pull_request` y caché npm explícita. Se conserva Node.js 22 para ejecutar el proyecto; el runtime interno de las acciones es independiente.

## Impacto

No cambian permisos, triggers, filtros de rutas ni pasos funcionales. El diff contiene únicamente dos referencias de versión.

## Validación local

- `npm ci`: correcto
- `npm audit`: 0 vulnerabilidades
- `npm test`: 46/46
- `npm run test:contract`: 43/43
- `npm run typecheck`: correcto
- `npm run build`: correcto
- `git diff --check`: correcto

La validación remota de este PR debe confirmar que desaparece la advertencia de runtime Node.js 20.

Closes #108