### PR TITLE
ci: auditar dependencias en cada PR

### DIFF
--- a/.github/workflows/game-session-contract.yml
+++ b/.github/workflows/game-session-contract.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit
+
       - name: Run GameSession contract tests
         run: npm run test:contract
 


### PR DESCRIPTION
## Qué cambia

Añade un paso `Audit dependencies` que ejecuta `npm audit` inmediatamente después de `npm ci` y antes de las pruebas.

## Motivo

#104 y #106 corrigieron vulnerabilidades altas y críticas, pero CI no comprobaba la seguridad del árbol instalado. Una actualización vulnerable del lockfile podía superar las pruebas y ser integrada.

## Impacto

Cualquier vulnerabilidad conocida detectada por npm bloqueará el job. El paso usa el árbol reproducible instalado desde `package-lock.json` y no necesita permisos adicionales.

No cambian triggers, permisos, acciones, Node.js 22 ni el resto de validaciones.

## Validación local

- `npm ci`: correcto
- `npm audit`: 0 vulnerabilidades
- `npm test`: 46/46
- `npm run test:contract`: 43/43
- `npm run typecheck`: correcto
- `npm run build`: correcto
- `git diff --check`: correcto

Closes #110