### PR TITLE
chore: configurar Dependabot para npm y GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Atlantic/Canary"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase"
+    groups:
+      npm-compatible:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Atlantic/Canary"
+    open-pull-requests-limit: 2
+    groups:
+      actions-compatible:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Qué cambia

Añade `.github/dependabot.yml` para supervisar semanalmente:

- dependencias npm;
- acciones usadas por GitHub Actions.

## Política

- Lunes a las 09:00 en `Atlantic/Canary`.
- Minor y patch agrupadas por ecosistema.
- Actualizaciones mayores separadas para revisión explícita.
- Máximo de 5 PRs npm y 2 PRs de Actions.
- npm usa `versioning-strategy: increase` para elevar también el mínimo declarado cuando corresponde.

## Motivo

#104, #106 y #108 demostraron que el repositorio carecía de detección programada de versiones obsoletas. #110 ya impide integrar vulnerabilidades conocidas; esta configuración añade prevención y mantenimiento periódico.

## Validación

- YAML analizado correctamente con un parser independiente.
- `npm audit`: 0 vulnerabilidades.
- `npm test`: 46/46.
- `npm run test:contract`: 43/43.
- `npm run typecheck`: correcto.
- `npm run build`: correcto.
- `git diff --check`: correcto.

GitHub activará la programación cuando el archivo alcance la rama por defecto.

Closes #112