### PR TITLE
ci: fijar GitHub Actions a commits inmutables

### DIFF
--- a/.github/workflows/game-session-contract.yml
+++ b/.github/workflows/game-session-contract.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Qué cambia

Sustituye las referencias móviles por commits completos verificados:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`;
- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`.

## Motivo

Un tag puede moverse; un SHA completo hace inmutable el código ejecutado por CI. Los comentarios de versión permiten a Dependabot mantener la documentación y proponer futuras actualizaciones.

## Impacto

No cambian triggers, permisos, entradas, Node.js 22 ni pasos. El diff modifica exclusivamente dos referencias `uses:`.

## Validación local

- `npm ci`: correcto
- `npm audit`: 0 vulnerabilidades
- `npm test`: 46/46
- `npm run test:contract`: 43/43
- `npm run typecheck`: correcto
- `npm run build`: correcto
- `git diff --check`: correcto

La validación remota debe confirmar la ejecución de ambos SHAs sin anotaciones nuevas.

Closes #114