### PR TITLE
chore(deps): mantener los tipos de Node alineados con el runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       timezone: "Atlantic/Canary"
     open-pull-requests-limit: 5
     versioning-strategy: "increase"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-compatible:
         patterns:


### PR DESCRIPTION
## Resumen

- mantiene `@types/node` alineado con el runtime Node 22 validado por CI;
- configura Dependabot para ignorar únicamente saltos `semver-major` de `@types/node`;
- conserva habilitadas las actualizaciones minor y patch de la línea vigente;
- documenta en #121 por qué #116 no debe integrarse.

## Validación

- YAML válido;
- estructura parseada: `@types/node -> version-update:semver-major`;
- `npm ci`;
- `npm audit`: 0 vulnerabilidades;
- `npm test`: 46/46;
- `npm run test:contract`: 43/43;
- `npm run typecheck`;
- `npm run build`;
- `git diff --check`.

Closes #121

Después de integrar este PR, #116 debe cerrarse como no planificado.